### PR TITLE
Update kafka to 3.4.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
   }
   
   object Kafka {
-    private val version = "2.8.2"
+    private val version = "3.4.0"
     val kafka           = "org.apache.kafka" %% "kafka"         % version
     val `kafka-clients` = "org.apache.kafka" %  "kafka-clients" % version
   }


### PR DESCRIPTION
I upgraded skafka in #442 , but forgot to update org.apache.kafka itself. This results in kafka 2.8 being selected when kafka-journal is used as a dependency.