### PR TITLE
Insert pointers sequentially in the correct order; fix test assert

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
@@ -35,12 +35,12 @@ object PointerStatements {
 
   object Insert {
 
-    def apply[F[_]: Parallel](
+    def apply[F[_]: Monad](
       first: Insert[F],
       second: Insert[F],
     ): Insert[F] = {
       (topic: Topic, partition: Partition, offset: Offset, created: Instant, updated: Instant) =>
-        first(topic, partition, offset, created, updated).parProductR(second(topic, partition, offset, created, updated))
+        first(topic, partition, offset, created, updated) >> second(topic, partition, offset, created, updated)
     }
 
     def of[F[_]: Monad: CassandraSession](

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -669,12 +669,12 @@ object ReplicatedCassandra {
           fallback <- PointerStatements.SelectIn.of[F](schema.pointer, consistencyConfig.read)
         } yield PointerStatements.SelectIn(select, fallback),
         for {
-          first  <- PointerStatements.Insert.of[F](schema.pointer, consistencyConfig.write)
-          second <- PointerStatements.Insert.of[F](schema.pointer2, consistencyConfig.write)
+          first  <- PointerStatements.Insert.of[F](schema.pointer2, consistencyConfig.write)
+          second <- PointerStatements.Insert.of[F](schema.pointer, consistencyConfig.write)
         } yield PointerStatements.Insert(first, second),
         for {
-          first  <- PointerStatements.Update.of[F](schema.pointer, consistencyConfig.write)
-          second <- PointerStatements.Update.of[F](schema.pointer2, consistencyConfig.write)
+          first  <- PointerStatements.Update.of[F](schema.pointer2, consistencyConfig.write)
+          second <- PointerStatements.Update.of[F](schema.pointer, consistencyConfig.write)
         } yield PointerStatements.Update(first, second),
         for {
           select   <- Pointer2Statements.SelectTopics.of[F](schema.pointer2, consistencyConfig.read)

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -233,7 +233,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
           partitionOffset  = expected.head.partitionOffset
           partition        = partitionOffset.partition
           offset          <- eventualJournal.offset(topic, partitionOffset.partition)
-          _                = offset.foreach { offset => partitionOffset.offset should be > offset }
+          _                = offset.foreach { offset => partitionOffset.offset should be >= offset }
           events          <- read(key)(_.nonEmpty)
           _                = events shouldEqual expected.toList
           pointer         <- journal.pointer


### PR DESCRIPTION
- use `pointer2` in `ReplicatedCassandra` as the first target of inserts and updates
- make `PointerStatements#Insert` sequential
- fix a flaky test in `ReplicatorIntSpec`