### PR TITLE
Limit number of concurrent consumers

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumeActionRecords.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumeActionRecords.scala
@@ -1,15 +1,19 @@
 package com.evolutiongaming.kafka.journal
 
 import cats.data.{NonEmptyList => Nel, NonEmptySet => Nes}
-import cats.effect.Resource
+import cats.effect.kernel.Concurrent
+import cats.effect.{Clock, Deferred, Resource}
 import cats.syntax.all._
+import cats.effect.syntax.resource._
 import cats.~>
 import com.evolutiongaming.catshelper.{BracketThrowable, Log}
 import com.evolutiongaming.kafka.journal.conversions.ConsRecordToActionRecord
+import com.evolutiongaming.kafka.journal.util.ResourcePool
 import com.evolutiongaming.kafka.journal.util.StreamHelper._
-import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import com.evolutiongaming.skafka.{Offset, Partition, Topic, TopicPartition}
 import com.evolutiongaming.sstream.Stream
 
+import scala.concurrent.duration.FiniteDuration
 
 trait ConsumeActionRecords[F[_]] {
 
@@ -18,8 +22,42 @@ trait ConsumeActionRecords[F[_]] {
 
 object ConsumeActionRecords {
 
+  @deprecated("use `of` instead", "2023-07-26")
   def apply[F[_] : BracketThrowable](
     consumer: Resource[F, Journals.Consumer[F]],
+    log: Log[F])(implicit
+    consRecordToActionRecord: ConsRecordToActionRecord[F]
+  ): ConsumeActionRecords[F] = apply1(_ => consumer, log)
+
+  def of[F[_] : Concurrent : Clock](
+    consumerPool: ResourcePool[F, Journals.Consumer[F]],
+    poolMetrics: ConsumerPoolMetrics[F],
+    log: Log[F],
+  )(implicit
+    consRecordToActionRecord: ConsRecordToActionRecord[F],
+  ): ConsumeActionRecords[F] = {
+
+    def consumerWithAcquisitionMetrics(topic: Topic): Resource[F, Journals.Consumer[F]] =
+      for {
+        startedAcquiringAt <- Clock[F].monotonic.toResource
+        deferred <- Deferred[F, FiniteDuration].toResource
+        consumer <- consumerPool.borrow.onFinalize {
+          for {
+            start <- deferred.get
+            end <- Clock[F].monotonic
+            _ <- poolMetrics.useTime(topic, end - start)
+          } yield ()
+        }
+        acquiredAt <- Clock[F].monotonic.toResource
+        _ <- deferred.complete(acquiredAt).toResource
+        _ <- poolMetrics.acquireTime(topic, acquiredAt - startedAcquiringAt).toResource
+      } yield consumer
+
+    apply1(consumerWithAcquisitionMetrics, log)
+  }
+
+  private[journal] def apply1[F[_] : BracketThrowable](
+    makeConsumer: Topic => Resource[F, Journals.Consumer[F]],
     log: Log[F])(implicit
     consRecordToActionRecord: ConsRecordToActionRecord[F]
   ): ConsumeActionRecords[F] = {
@@ -51,14 +89,13 @@ object ConsumeActionRecords {
       }
 
       for {
-        consumer <- consumer.toStream
+        consumer <- makeConsumer(key.topic).toStream
         _        <- seek(consumer).toStream
         records  <- Stream.repeat(poll(consumer))
         record   <- records.toStream1[F]
       } yield record
     }
   }
-
 
   implicit class ConsumeActionRecordsOps[F[_]](val self: ConsumeActionRecords[F]) extends AnyVal {
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumerPoolMetrics.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumerPoolMetrics.scala
@@ -1,0 +1,62 @@
+package com.evolutiongaming.kafka.journal
+
+import cats.Applicative
+import cats.effect.Resource
+import cats.syntax.all._
+import com.evolutiongaming.skafka._
+import com.evolutiongaming.smetrics._
+import com.evolutiongaming.smetrics.MetricsHelper._
+
+import scala.concurrent.duration.FiniteDuration
+
+trait ConsumerPoolMetrics[F[_]] {
+
+  def acquireTime(topic: Topic, time: FiniteDuration): F[Unit]
+
+  def useTime(topic: Topic, time: FiniteDuration): F[Unit]
+}
+
+object ConsumerPoolMetrics {
+
+  def of[F[_]](
+    registry: CollectorRegistry[F],
+    prefix: String = "journal"
+  ): Resource[F, ConsumerPoolMetrics[F]] = {
+
+    val timeSummary = registry.summary(
+      name = s"${prefix}_consumer_pool_time_spent",
+      help = "Time spent acquiring/using consumers",
+      quantiles = Quantiles.Default,
+      labels = LabelNames("topic", "type")
+    )
+
+    for {
+      timeSummary <- timeSummary
+    } yield {
+      class Main
+      new Main with ConsumerPoolMetrics[F] {
+
+        def observeLatency(name: String, topic: Topic, latency: FiniteDuration) =
+          timeSummary.labels(topic, name).observe(latency.toNanos.nanosToSeconds)
+
+        override def acquireTime(topic: Topic, time: FiniteDuration): F[Unit] =
+          observeLatency("acquire", topic, time)
+
+        override def useTime(topic: Topic, time: FiniteDuration): F[Unit] =
+          observeLatency("use", topic, time)
+      }
+    }
+  }
+
+  def empty[F[_] : Applicative]: ConsumerPoolMetrics[F] = const(().pure[F])
+
+  def const[F[_]](unit: F[Unit]): ConsumerPoolMetrics[F] = {
+    class Const
+    new Const with ConsumerPoolMetrics[F] {
+
+      override def acquireTime(topic: Topic, time: FiniteDuration): F[Unit] = unit
+
+      override def useTime(topic: Topic, time: FiniteDuration): F[Unit] = unit
+    }
+  }
+}

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumerSemaphoreMetrics.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/ConsumerSemaphoreMetrics.scala
@@ -1,0 +1,62 @@
+package com.evolutiongaming.kafka.journal
+
+import cats.Applicative
+import cats.effect.Resource
+import cats.syntax.all._
+import com.evolutiongaming.skafka._
+import com.evolutiongaming.smetrics._
+import com.evolutiongaming.smetrics.MetricsHelper._
+
+import scala.concurrent.duration.FiniteDuration
+
+trait ConsumerSemaphoreMetrics[F[_]] {
+
+  def acquireTime(topic: Topic, time: FiniteDuration): F[Unit]
+
+  def useTime(topic: Topic, time: FiniteDuration): F[Unit]
+}
+
+object ConsumerSemaphoreMetrics {
+
+  def of[F[_]](
+    registry: CollectorRegistry[F],
+    prefix: String = "journal"
+  ): Resource[F, ConsumerSemaphoreMetrics[F]] = {
+
+    val timeSummary = registry.summary(
+      name = s"${prefix}_consumer_semaphore_time_spent",
+      help = "Time spent acquiring/using consumers",
+      quantiles = Quantiles.Default,
+      labels = LabelNames("topic", "type")
+    )
+
+    for {
+      timeSummary <- timeSummary
+    } yield {
+      class Main
+      new Main with ConsumerSemaphoreMetrics[F] {
+
+        def observeLatency(name: String, topic: Topic, latency: FiniteDuration) =
+          timeSummary.labels(topic, name).observe(latency.toNanos.nanosToSeconds)
+
+        override def acquireTime(topic: Topic, time: FiniteDuration): F[Unit] =
+          observeLatency("acquire", topic, time)
+
+        override def useTime(topic: Topic, time: FiniteDuration): F[Unit] =
+          observeLatency("use", topic, time)
+      }
+    }
+  }
+
+  def empty[F[_] : Applicative]: ConsumerSemaphoreMetrics[F] = const(().pure[F])
+
+  def const[F[_]](unit: F[Unit]): ConsumerSemaphoreMetrics[F] = {
+    class Const
+    new Const with ConsumerSemaphoreMetrics[F] {
+
+      override def acquireTime(topic: Topic, time: FiniteDuration): F[Unit] = unit
+
+      override def useTime(topic: Topic, time: FiniteDuration): F[Unit] = unit
+    }
+  }
+}

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/GuardedConsumer.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/GuardedConsumer.scala
@@ -1,0 +1,50 @@
+package com.evolutiongaming.kafka.journal
+
+import cats.effect._
+import cats.effect.syntax.all._
+import cats.effect.std._
+import cats.syntax.all._
+import com.evolutiongaming.catshelper._
+import com.evolutiongaming.skafka.Topic
+
+import scala.concurrent.duration.FiniteDuration
+
+object GuardedConsumer {
+
+  /** Guarantees that no more than `semaphore.maxPermits` consumers exist simultaneously.
+    */
+  def of[F[_]: Temporal](
+    consumer: Resource[F, Journals.Consumer[F]],
+    semaphore: Semaphore[F],
+    acquireTimeout: FiniteDuration,
+    metrics: ConsumerSemaphoreMetrics[F],
+    topic: Topic,
+  ): Resource[F, Journals.Consumer[F]] = {
+
+    def acquire: F[F[FiniteDuration]] = {
+      val acquireWithTimeout = semaphore
+        .acquire
+        .timeoutTo(
+          acquireTimeout,
+          Concurrent[F].raiseError(new Exception("Timeout when trying to acquire a consumer"))
+        )
+
+      for {
+        d       <- MeasureDuration[F].start
+        _       <- acquireWithTimeout
+        d       <- d
+        _       <- metrics.acquireTime(topic, d)
+        useTime <- MeasureDuration[F].start
+      } yield useTime
+    }
+
+    def release(useTime: F[FiniteDuration]): F[Unit] =
+      for {
+        _       <- semaphore.release
+        useTime <- useTime
+        _       <- metrics.useTime(topic, useTime)
+      } yield ()
+
+    Resource.make(acquire)(release).flatMap(_ => consumer)
+  }
+}

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
@@ -11,7 +11,7 @@ import com.evolutiongaming.kafka.journal.util.StreamHelper._
 import com.evolutiongaming.skafka.{Bytes => _, _}
 import com.evolutiongaming.sstream.Stream
 import pureconfig.ConfigReader
-import pureconfig.generic.semiauto.deriveReader
+import pureconfig.generic.semiauto._
 
 import scala.concurrent.duration._
 
@@ -328,5 +328,26 @@ object Journal {
     val default: CallTimeThresholds = CallTimeThresholds()
 
     implicit val configReaderCallTimeThresholds: ConfigReader[CallTimeThresholds] = deriveReader[CallTimeThresholds]
+  }
+
+  sealed trait ConsumerPoolConfig
+
+  object ConsumerPoolConfig {
+    /**
+     * The size of consumer pool will be ceil(scale * (CPUs available))
+     */
+    final case class AutoScale(scale: Double) extends ConsumerPoolConfig
+
+    object AutoScale {
+      implicit val configReader: ConfigReader[AutoScale] = deriveReader
+    }
+
+    final case class FixedSize(size: Int) extends ConsumerPoolConfig
+
+    object FixedSize {
+      implicit val configReader: ConfigReader[FixedSize] = deriveReader
+    }
+
+    implicit val configReader: ConfigReader[ConsumerPoolConfig] = deriveReader
   }
 }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/JournalConfig.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/JournalConfig.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.journal
 
+import com.evolutiongaming.kafka.journal.Journal.ConsumerPoolConfig
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
@@ -21,6 +22,8 @@ import scala.concurrent.duration._
   *   Configuration of head cache, which is, currently, only about enabling or
   *   disabling it. See [[HeadCache]] for more details on what is head cache
   *   and how it works.
+  * @param consumerPoolSize
+  *   Size of the pool that will be used for recovery. See [[ConsumeActionRecords]].
   */
 final case class JournalConfig(
   pollTimeout: FiniteDuration = 10.millis,

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/util/ResourcePool.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/util/ResourcePool.scala
@@ -1,0 +1,36 @@
+package com.evolutiongaming.kafka.journal.util
+
+import cats.effect.implicits.effectResourceOps
+import cats.effect.std.Queue
+import cats.effect.{Concurrent, Resource}
+import cats.syntax.all._
+
+private[journal] trait ResourcePool[F[_], O] {
+
+  /**
+   * `acquire` function of the Resource semantically blocks if there are no objects available.
+   *
+   * `release` function of the Resource returns the object to the pool.
+   * Note that it will NOT deallocate the object.
+   */
+  def borrow: Resource[F, O]
+}
+
+private[journal] object ResourcePool {
+
+  /**
+   *  Objects are allocated when a pool is created and deallocated when it shuts down.
+   */
+  def fixedSize[F[_]: Concurrent, O](objectOf: Resource[F, O], poolSize: Int): Resource[F, ResourcePool[F, O]] = {
+    for {
+      objects <- Vector.fill(poolSize)(objectOf).sequence
+      unused <- Queue.bounded[F, O](poolSize).toResource
+      _ <- objects.traverse(unused.offer).toResource
+    } yield {
+      class Main
+      new Main with ResourcePool[F, O] {
+        override def borrow: Resource[F, O] = Resource.make(unused.take)(unused.offer)
+      }
+    }
+  }
+}

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/GuardedConsumerSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/GuardedConsumerSpec.scala
@@ -1,0 +1,79 @@
+package com.evolutiongaming.kafka.journal
+
+import cats.data.NonEmptySet
+import cats.effect._
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+import com.evolutiongaming.catshelper.LogOf
+import cats.effect.unsafe.implicits.global
+import com.evolutiongaming.skafka.{Offset, TopicPartition}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import java.util.UUID
+
+class GuardedConsumerSpec extends AnyFunSuite with Matchers {
+
+  implicit val logOf: LogOf[IO] = LogOf.empty
+
+  case class TestConsumer(id: UUID) extends Journals.Consumer[IO] {
+    override def assign(partitions: NonEmptySet[TopicPartition]): IO[Unit] = ???
+    override def seek(partition: TopicPartition, offset: Offset): IO[Unit] = ???
+    override def poll: IO[ConsRecords] = ???
+    override def toString = id.toString.take(8)
+  }
+
+  object TestConsumer {
+    def create = IO.delay(UUID.randomUUID()).map(TestConsumer(_))
+  }
+
+  case class ConsumerCount(current: Int, max: Int) {
+
+    def inc = ConsumerCount(current + 1, math.max(max, current + 1))
+
+    def dec = ConsumerCount(current - 1, max)
+  }
+
+  object ConsumerCount {
+    val Zero = ConsumerCount(0, 0)
+  }
+
+  def makeConsumer(count: Ref[IO, ConsumerCount]) =
+    Resource.make {
+      count.update(_.inc) *> TestConsumer.create
+    } { _ =>
+      count.update(_.dec)
+    }
+
+  test("1") {
+
+    val permits = 16
+    val sleepDuration = 2.milliseconds
+    val timesToAcquire = 8000
+    val acquireTimeout = 100500.hours
+
+    (for {
+      log <- LogOf.log[IO](getClass.getName)
+
+      consumerCount <- Ref.of[IO, ConsumerCount](ConsumerCount.Zero)
+      consumer = makeConsumer(consumerCount)
+
+      semaphore <- Semaphore[IO](permits)
+
+      guardedConsumer = GuardedConsumer.of[IO](
+        consumer,
+        semaphore,
+        acquireTimeout,
+        ConsumerSemaphoreMetrics.empty,
+        "topic"
+      )
+
+      _ <- (1 to timesToAcquire).toVector.parTraverse_ { _ =>
+        guardedConsumer.use(_ => IO.sleep(sleepDuration)) // emulate using a consumer
+      }
+
+      _ <- consumerCount.get.map(_.max shouldEqual permits)
+    } yield ()).unsafeRunSync()
+  }
+}

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/util/ResourcePoolSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/util/ResourcePoolSpec.scala
@@ -1,0 +1,55 @@
+package com.evolutiongaming.kafka.journal.util
+
+import cats.effect.{IO, Ref}
+import cats.effect.kernel.Resource
+
+import scala.concurrent.duration._
+import com.evolutiongaming.catshelper.LogOf
+import cats.syntax.all._
+import cats.effect.syntax.all._
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+
+class ResourcePoolSpec extends AnyFunSuite with Matchers {
+
+  case class TestObject(id: UUID) {
+    override def toString = id.toString.take(8)
+  }
+
+  object TestObject {
+    def create = IO.delay(UUID.randomUUID()).map(TestObject(_))
+  }
+
+  implicit val logOf: LogOf[IO] = LogOf.empty
+
+  test("Pool should allocate and deallocate exactly `poolSize` objects") {
+    val poolSize = 250
+
+    val sleepDuration = 20.milliseconds
+    // TODO: use CE3 test runtime after dropping CE2 support.
+    // It will allow increasing sleepDuration but no actual sleeping will happen.
+
+    val timesToAcquire = 8000
+
+    (for {
+      useCount <- Ref.of[IO, Int](0)
+      releaseCount <- Ref.of[IO, Int](0)
+      log <- LogOf.log[IO](getClass.getName)
+      objectOf = Resource.make {
+        useCount.update(_ + 1) *> TestObject.create
+      } { _ =>
+        releaseCount.update(_ + 1)
+      }
+      _ <- ResourcePool.fixedSize[IO, TestObject](objectOf, poolSize).use { pool =>
+        (1 to timesToAcquire).toVector.parTraverse_ { _ =>
+          pool.borrow.use(_ => IO.sleep(sleepDuration)) // emulate using an object
+        }
+      }
+      _ <- useCount.get.map(_ shouldEqual poolSize)
+      _ <- releaseCount.get.map(_ shouldEqual poolSize)
+    } yield ()).unsafeRunSync()
+  }
+}

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/KafkaJournalConfig.scala
@@ -1,6 +1,6 @@
 package akka.persistence.kafka.journal
 
-import com.evolutiongaming.kafka.journal.Journal.CallTimeThresholds
+import com.evolutiongaming.kafka.journal.Journal.{CallTimeThresholds, ConsumerPoolConfig}
 import com.evolutiongaming.kafka.journal.JournalConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig
 import pureconfig.generic.semiauto.{deriveEnumerationReader, deriveReader}
@@ -15,7 +15,9 @@ final case class KafkaJournalConfig(
   stopTimeout: FiniteDuration = 1.minute,
   maxEventsInBatch: Int = 100,
   callTimeThresholds: CallTimeThresholds = CallTimeThresholds.default,
-  jsonCodec: KafkaJournalConfig.JsonCodec = KafkaJournalConfig.JsonCodec.Default)
+  jsonCodec: KafkaJournalConfig.JsonCodec = KafkaJournalConfig.JsonCodec.Default,
+  consumerPool: Option[ConsumerPoolConfig] = None,
+)
 
 object KafkaJournalConfig {
 


### PR DESCRIPTION
This is an auxiliary PR, #500 is the main PR 

I tried to use `cats.effect.std.Backpressure` but adding timeout to it looked ugly. Implementation of Backpressure is pretty simple so I decided to write it myself using `bracket`. Then after some more experimentation I arrived at what I have now.