### PR TITLE
Reimplement deduplication logic:

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -4,7 +4,7 @@ import cats.effect.kernel.{Async, Temporal}
 import cats.effect.syntax.resource._
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
-import cats.{Monad, Parallel}
+import cats.{MonadThrow, Parallel}
 import com.evolutiongaming.catshelper.{LogOf, MeasureDuration, ToTry}
 import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.eventual._
@@ -76,7 +76,7 @@ object EventualCassandra {
 
   private sealed abstract class Main
 
-  def apply[F[_]: Monad](statements: Statements[F]): EventualJournal[F] = {
+  def apply[F[_]: MonadThrow](statements: Statements[F]): EventualJournal[F] = {
 
     new Main with EventualJournal[F] {
 
@@ -107,6 +107,18 @@ object EventualCassandra {
                 }
               }
               .map { case (record, _) => record }
+              .stateful(from) { case (seqNr, record) =>
+                if (seqNr <= record.seqNr) {
+                  val seqNr1 = record
+                    .seqNr
+                    .next[Option]
+                  (seqNr1, Stream[F].single(record))
+                } else {
+                  val msg = s"Data integrity violated: seqNr $seqNr duplicated in multiple records from eventual journal for key $key"
+                  val err = new JournalError(msg)
+                  (seqNr.some, err.raiseError[F, EventRecord[EventualPayloadAndType]].toStream)
+                }
+              }
           }
 
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journals.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journals.scala
@@ -180,18 +180,6 @@ object Journals {
               eventual
                 .read(key, from)
                 .mapM { _.traverse(eventualRead.apply) }
-                .stateful(from) { case (seqNr, a) =>
-                  if (seqNr <= a.seqNr) {
-                    val seqNr1 = a
-                      .seqNr
-                      .next[Option]
-                    (seqNr1, Stream[F].single(a))
-                  } else {
-                    val msg = s"Data integrity violated: seqNr $seqNr duplicated in multiple records from eventual journal for key $key"
-                    val err = new JournalError(msg)
-                    (seqNr.some, err.raiseError[F, EventRecord[A]].toStream)
-                  }
-                }
             }
 
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journals.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journals.scala
@@ -180,6 +180,18 @@ object Journals {
               eventual
                 .read(key, from)
                 .mapM { _.traverse(eventualRead.apply) }
+                .stateful(from) { case (seqNr, a) =>
+                  if (seqNr <= a.seqNr) {
+                    val seqNr1 = a
+                      .seqNr
+                      .next[Option]
+                    (seqNr1, Stream[F].single(a))
+                  } else {
+                    val msg = s"Data integrity violated: seqNr $seqNr duplicated in multiple records from eventual journal for key $key"
+                    val err = new JournalError(msg)
+                    (seqNr.some, err.raiseError[F, EventRecord[A]].toStream)
+                  }
+                }
             }
 
 
@@ -203,7 +215,7 @@ object Journals {
                           .dec[Try]
                           .toOption
                           .max { offset0 }
-                        for {
+                        val records = for {
                           record <- stream(offset)
                           action <- record.action match {
                             case a: Action.Append => Stream[F].single(a)
@@ -220,6 +232,16 @@ object Journals {
                           if event.seqNr >= seqNr
                         } yield {
                           EventRecord(action, event, record.partitionOffset, events.metadata)
+                        }
+                        records.stateful(seqNr) { case (seqNr, a) =>
+                          if (seqNr <= a.seqNr) {
+                            val seqNr1 = a
+                              .seqNr
+                              .next[Option]
+                            (seqNr1, Stream[F].single(a))
+                          } else {
+                            (seqNr.some, Stream[F].empty[EventRecord[A]])
+                          }
                         }
                       }
                       event     <- readEventual(seqNr).flatMapLast {
@@ -261,36 +283,12 @@ object Journals {
               }
             }
 
-            val stream = for {
+            for {
               headAndStream  <- headAndStream(key, from).toStream
               (head, stream)  = headAndStream
               _              <- log.debug(s"$key read info: $head").toStream
               eventRecord    <- read(head, stream)
             } yield eventRecord
-
-            val empty = Option.empty[EventRecord[A]]
-
-            stream.map(Option(_)).concat(Stream.single(empty)).stateful(empty) {
-              case (None, None) =>
-                None -> Stream.empty
-
-              case (None, Some(record)) =>
-                record.some.some -> Stream.empty
-
-              case (Some(prevRecord), Some(record)) if prevRecord.seqNr == record.seqNr =>
-                val logError = log.warn(s"Duplicated events found during recovery: $prevRecord and $record").toStream
-                record.some.some-> logError *> Stream.empty
-
-              case (Some(prevRecord), Some(record)) if prevRecord.seqNr > record.seqNr =>
-                val logError = log.warn(s"Invalid records order: $prevRecord, $record").toStream
-                prevRecord.some.some -> logError *> Stream.empty
-
-              case (Some(prevRecord), Some(record)) =>
-                record.some.some -> Stream.single(prevRecord)
-
-              case (Some(prevRecord), None) =>
-                None -> Stream.single(prevRecord)
-            }
           }
 
 

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
@@ -1,11 +1,11 @@
 package com.evolutiongaming.kafka.journal
 
+import cats.Monad
 import cats.data.{NonEmptyList => Nel}
 import cats.effect.kernel.Sync
-import cats.effect.unsafe.implicits.global
 import cats.effect.{Clock, IO}
 import cats.syntax.all._
-import cats.{Monad, MonadError}
+import cats.effect.unsafe.implicits.global
 import com.evolutiongaming.catshelper.ClockHelper._
 import com.evolutiongaming.catshelper.{FromTry, Log, MeasureDuration}
 import com.evolutiongaming.concurrent.CurrentThreadExecutionContext
@@ -241,13 +241,82 @@ class JournalSpec extends AnyWordSpec with Matchers {
 
   "Journal" when {
 
+    "eventual journal has duplicated seqNr" should {
+      val journal = SeqNrJournal(
+        StateT.eventualJournal.withDuplicates,
+        StateT.consumeActionRecords,
+        StateT.produceAction,
+        StateT.headCache)
+
+      for {
+        size <- 1 to 5
+        seqNrs = (1 to size).toList.map { a => SeqNr.unsafe(a) }
+        combination <- Combinations(seqNrs)
+      } {
+
+        val seqNrLast = seqNrs.lastOption
+
+        def createAndAppend(f: (SeqNrJournal[StateT], Option[Offset]) => StateT[Assertion]): Assertion = {
+            def append(seqNrs: Nel[SeqNr]) = {
+              journal
+                .append(seqNrs.head, seqNrs.tail: _*)
+                .map { _.some }
+            }
+
+            val result = for {
+              offset <- combination.foldLeftM(none[Offset]) { (_, seqNrs) => append(seqNrs) }
+              offsetNext = offset.map { _.inc[Try].get }
+              result <- f(journal, offsetNext)
+            } yield result
+
+          result
+            .run(State.empty)
+            .map { case (_, result) => result }
+            .unsafeRunSync()
+        }
+
+        val name = combination
+          .map { _.toList.mkString("[", ",", "]") }
+          .mkString(",")
+
+        s"append, $name" in {
+          assertThrows[JournalError] {
+            createAndAppend { case (journal, _) =>
+              for {
+                a <- journal.read(SeqRange.all)
+              } yield {
+                a shouldEqual seqNrs
+              }
+            }
+          }
+        }
+
+        s"read, $name" in {
+          assertThrows[JournalError] {
+            createAndAppend { case (journal, _) =>
+              for {
+                a <- journal.read(SeqRange.all)
+                _ = a shouldEqual seqNrs
+                last = seqNrLast getOrElse SeqNr.min
+                a <- journal.read(SeqNr.min to last)
+                _ = a shouldEqual seqNrs
+                a <- journal.read(SeqNr.min to last.next[Option].getOrElse(last))
+              } yield {
+                a shouldEqual seqNrs
+              }
+            }
+          }
+        }
+      }
+    }
+
     for {
       (headCacheStr, headCache) <- List(
         ("invalid", HeadCache.const(none[HeadInfo].pure[StateT])),
         ("valid"  , StateT.headCache))
       (duplicatesStr, consumeActionRecordsOf, eventualJournalOf) <- List(
         ("off", (a: ConsumeActionRecords[StateT]) => a               , (a: EventualJournal[StateT]) => a),
-        ("on" , (a: ConsumeActionRecords[StateT]) => a.withDuplicates, (a: EventualJournal[StateT]) => a.withDuplicates))
+        ("Kafka on" , (a: ConsumeActionRecords[StateT]) => a.withDuplicates, (a: EventualJournal[StateT]) => a))
     } {
 
       def test(
@@ -434,7 +503,6 @@ object JournalSpec {
   object SeqNrJournal {
 
     def apply[F[_] : Monad, A](journals: Journals[F])(implicit
-      F: MonadError[F, Throwable],
       kafkaRead: KafkaRead[F, A],
       eventualRead: EventualRead[F, A],
       kafkaWrite: KafkaWrite[F, A],
@@ -443,7 +511,6 @@ object JournalSpec {
     }
 
     def apply[F[_] : Monad, A](journal: Journal[F])(implicit
-      F: MonadError[F, Throwable],
       kafkaRead: KafkaRead[F, A],
       eventualRead: EventualRead[F, A],
       kafkaWrite: KafkaWrite[F, A],
@@ -469,13 +536,7 @@ object JournalSpec {
             .read(range.from)
             .dropWhile { _.seqNr < range.from }
             .takeWhile { _.seqNr <= range.to }
-            .flatMap{ r =>
-              if (r.timestamp == Instant.MIN) {
-                MonadError[Stream[F, *], Throwable].raiseError[SeqNr](new RuntimeException("Old duplicated event is read!"))
-              } else {
-                Stream.single[F, SeqNr](r.seqNr)
-              }
-            }
+            .map { _.seqNr }
             .toList
         }
 
@@ -745,17 +806,17 @@ object JournalSpec {
 
 
   implicit class ConsumeActionRecordsOps[F[_]](val self: ConsumeActionRecords[F]) extends AnyVal {
-    def withDuplicates(implicit monac: Monad[F]): ConsumeActionRecords[F] = new ConsumeActionRecords[F] {
+    def withDuplicates(implicit F: Monad[F]): ConsumeActionRecords[F] = new ConsumeActionRecords[F] {
       def apply(key: Key, partition: Partition, from: Offset) = {
         self
           .apply(key, partition, from)
-          .withDuplicates()
+          .withDuplicates
       }
     }
   }
 
   implicit class EventualJournalOps[F[_]](val self: EventualJournal[F]) extends AnyVal {
-    def withDuplicates(implicit monad: Monad[F]): EventualJournal[F] = new EventualJournal[F] {
+    def withDuplicates(implicit F: Monad[F]): EventualJournal[F] = new EventualJournal[F] {
 
       def pointer(key: Key) = self.pointer(key)
 
@@ -764,7 +825,7 @@ object JournalSpec {
       def read(key: Key, from: SeqNr) = {
         self
           .read(key, from)
-          .withDuplicates(_.copy(timestamp = Instant.MIN))
+          .withDuplicates
       }
 
       def ids(topic: Topic) = self.ids(topic)
@@ -772,9 +833,11 @@ object JournalSpec {
   }
 
   implicit class StreamOps[F[_], A](val self: Stream[F, A]) extends AnyVal {
-    def withDuplicates(corruptOld: A => A = identity)(implicit F: Monad[F]): Stream[F, A] = {
+    def withDuplicates(implicit F: Monad[F]): Stream[F, A] = {
       self.flatMap { a =>
-        List(corruptOld(a), a).toStream1[F]
+        List
+          .fill(2)(a)
+          .toStream1[F]
       }
     }
   }

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
@@ -241,82 +241,13 @@ class JournalSpec extends AnyWordSpec with Matchers {
 
   "Journal" when {
 
-    "eventual journal has duplicated seqNr" should {
-      val journal = SeqNrJournal(
-        StateT.eventualJournal.withDuplicates,
-        StateT.consumeActionRecords,
-        StateT.produceAction,
-        StateT.headCache)
-
-      for {
-        size <- 1 to 5
-        seqNrs = (1 to size).toList.map { a => SeqNr.unsafe(a) }
-        combination <- Combinations(seqNrs)
-      } {
-
-        val seqNrLast = seqNrs.lastOption
-
-        def createAndAppend(f: (SeqNrJournal[StateT], Option[Offset]) => StateT[Assertion]): Assertion = {
-            def append(seqNrs: Nel[SeqNr]) = {
-              journal
-                .append(seqNrs.head, seqNrs.tail: _*)
-                .map { _.some }
-            }
-
-            val result = for {
-              offset <- combination.foldLeftM(none[Offset]) { (_, seqNrs) => append(seqNrs) }
-              offsetNext = offset.map { _.inc[Try].get }
-              result <- f(journal, offsetNext)
-            } yield result
-
-          result
-            .run(State.empty)
-            .map { case (_, result) => result }
-            .unsafeRunSync()
-        }
-
-        val name = combination
-          .map { _.toList.mkString("[", ",", "]") }
-          .mkString(",")
-
-        s"append, $name" in {
-          assertThrows[JournalError] {
-            createAndAppend { case (journal, _) =>
-              for {
-                a <- journal.read(SeqRange.all)
-              } yield {
-                a shouldEqual seqNrs
-              }
-            }
-          }
-        }
-
-        s"read, $name" in {
-          assertThrows[JournalError] {
-            createAndAppend { case (journal, _) =>
-              for {
-                a <- journal.read(SeqRange.all)
-                _ = a shouldEqual seqNrs
-                last = seqNrLast getOrElse SeqNr.min
-                a <- journal.read(SeqNr.min to last)
-                _ = a shouldEqual seqNrs
-                a <- journal.read(SeqNr.min to last.next[Option].getOrElse(last))
-              } yield {
-                a shouldEqual seqNrs
-              }
-            }
-          }
-        }
-      }
-    }
-
     for {
       (headCacheStr, headCache) <- List(
         ("invalid", HeadCache.const(none[HeadInfo].pure[StateT])),
         ("valid"  , StateT.headCache))
       (duplicatesStr, consumeActionRecordsOf, eventualJournalOf) <- List(
         ("off", (a: ConsumeActionRecords[StateT]) => a               , (a: EventualJournal[StateT]) => a),
-        ("Kafka on" , (a: ConsumeActionRecords[StateT]) => a.withDuplicates, (a: EventualJournal[StateT]) => a))
+        ("on" , (a: ConsumeActionRecords[StateT]) => a.withDuplicates, (a: EventualJournal[StateT]) => a))
     } {
 
       def test(
@@ -815,22 +746,6 @@ object JournalSpec {
     }
   }
 
-  implicit class EventualJournalOps[F[_]](val self: EventualJournal[F]) extends AnyVal {
-    def withDuplicates(implicit F: Monad[F]): EventualJournal[F] = new EventualJournal[F] {
-
-      def pointer(key: Key) = self.pointer(key)
-
-      def offset(topic: Topic, partition: Partition): F[Option[Offset]] = self.offset(topic, partition)
-
-      def read(key: Key, from: SeqNr) = {
-        self
-          .read(key, from)
-          .withDuplicates
-      }
-
-      def ids(topic: Topic) = self.ids(topic)
-    }
-  }
 
   implicit class StreamOps[F[_], A](val self: Stream[F, A]) extends AnyVal {
     def withDuplicates(implicit F: Monad[F]): Stream[F, A] = {

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalPerfSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalPerfSpec.scala
@@ -72,45 +72,47 @@ class JournalPerfSpec extends AsyncWordSpec with JournalSuite {
 
     val key = Key.random[IO]("journal").unsafeRunSync()
 
-    lazy val append = {
+    def append(journals: Journals[IO]) = {
 
-      def append(journals: Journals[IO]) = {
+      val journal = JournalTest(journals(key), timestamp)
 
-        val journal = JournalTest(journals(key), timestamp)
-
-        val expected = {
-          val expected = for {
-            n     <- (0 to events).toList
-            seqNr <- SeqNr.min.map[Option](_ + n)
-          } yield {
-            event(seqNr)
-          }
-          Nel.fromListUnsafe(expected)
+      val expected = {
+        val expected = for {
+          n     <- (0 until events).toList
+          seqNr <- SeqNr.min.map[Option](_ + n)
+        } yield {
+          event(seqNr)
         }
-
-        def appendNoise = {
-          (0 to events)
-            .toList
-            .parFoldMap1 { _ =>
-              val e = event(SeqNr.min)
-              for {
-                _       <- journal.append(Nel.of(e))
-                key     <- Key.random[IO]("journal")
-                journal  = JournalTest(journals(key), timestamp)
-                _       <- journal.append(Nel.of(e))
-              } yield {}
-            }
-        }
-
-        for {
-          _ <- journal.pointer
-          _ <- expected.groupedNel(10).foldMap { events => journal.append(events).void }
-          _ <- appendNoise
-        } yield {}
+        Nel.fromListUnsafe(expected)
       }
 
-      journalOf(eventualJournal).use(append)
+      def appendNoise = {
+        (1 to events)
+          .toList
+          .parFoldMap1 { n =>
+            val e = event(SeqNr.unsafe(events + n))
+            for {
+              _       <- journal.append(Nel.of(e))
+              key     <- Key.random[IO]("journal")
+              journal  = JournalTest(journals(key), timestamp)
+              _       <- journal.append(Nel.of(e))
+            } yield {}
+          }
+      }
+
+      for {
+        _ <- journal.pointer
+        _ <- expected.groupedNel(10).foldMap { events => journal.append(events).void }
+        _ <- appendNoise
+      } yield {}
     }
+
+    val appendToJournal = for {
+      _ <- awaitResources
+      _ <- journalOf(eventualJournal).use(append)
+    } yield {}
+
+    appendToJournal.start.void.unsafeRunSync()
 
     for {
       (eventualName, expected, eventual) <- List(
@@ -126,7 +128,6 @@ class JournalPerfSpec extends AsyncWordSpec with JournalSuite {
 
       s"measure pointer $many times, $name" in {
         val result = for {
-          _       <- append
           _       <- journal.pointer
           average <- measure { journal.pointer }
         } yield {

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalSuite.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalSuite.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.syntax.resource._
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.catshelper.FromFuture
 import com.evolutiongaming.kafka.journal.CassandraSuite._
 import com.evolutiongaming.kafka.journal.IOSuite._
 import com.evolutiongaming.kafka.journal.conversions.{KafkaRead, KafkaWrite}
@@ -21,6 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import pureconfig.{ConfigReader, ConfigSource}
 
 import java.time.Instant
+import scala.concurrent.Promise
 
 
 trait JournalSuite extends ActorSuite with Matchers { self: Suite =>
@@ -59,9 +61,13 @@ trait JournalSuite extends ActorSuite with Matchers { self: Suite =>
       .unsafeRunSync()
   }
 
+  private val await = Promise[Unit]()
+  val awaitResources: IO[Unit] = FromFuture[IO].apply(await.future)
+
   override def beforeAll() = {
     super.beforeAll()
     IntegrationSuite.start()
+    await.success({})
     //    eventual
     //    producer
   }


### PR DESCRIPTION
on receiving records with duplicated `seqNr` from Kafka - take first one 
on receiving records with duplicated `seqNr` from Cassandra - raise error