### PR TITLE
Extract keyspace configuration to a separate class

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
@@ -7,17 +7,16 @@ import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
 import com.evolutiongaming.scassandra.CreateKeyspaceIfNotExists
 
 trait CreateKeyspace[F[_]] {
-  def apply(config: SchemaConfig.Keyspace): F[Unit]
+  def apply(config: KeyspaceConfig): F[Unit]
 }
 
 object CreateKeyspace { self =>
 
-  def empty[F[_] : Applicative]: CreateKeyspace[F] = (_: SchemaConfig.Keyspace) => ().pure[F]
-  
+  def empty[F[_] : Applicative]: CreateKeyspace[F] = (_: KeyspaceConfig) => ().pure[F]
 
   def apply[F[_] : Monad : CassandraCluster : CassandraSession : LogOf]: CreateKeyspace[F] = new CreateKeyspace[F] {
-    
-    def apply(config: SchemaConfig.Keyspace) = {
+
+    def apply(config: KeyspaceConfig) = {
       if (config.autoCreate) {
         val keyspace = config.name
 
@@ -36,7 +35,7 @@ object CreateKeyspace { self =>
           result   <- metadata.fold(create)(_ => ().pure[F])
         } yield result
       } else {
-        ().pure[F]                          
+        ().pure[F]
       }
     }
   }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/KeyspaceConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/KeyspaceConfig.scala
@@ -1,0 +1,18 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import com.evolutiongaming.scassandra.ReplicationStrategyConfig
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+final case class KeyspaceConfig(
+  name: String = "journal",
+  replicationStrategy: ReplicationStrategyConfig = ReplicationStrategyConfig.Default,
+  autoCreate: Boolean = true
+)
+
+object KeyspaceConfig {
+
+  val default: KeyspaceConfig = KeyspaceConfig()
+
+  implicit val configReaderKeyspace: ConfigReader[KeyspaceConfig] = deriveReader
+}

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
@@ -1,12 +1,10 @@
 package com.evolutiongaming.kafka.journal.eventual.cassandra
 
-import com.evolutiongaming.scassandra.ReplicationStrategyConfig
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
-
 final case class SchemaConfig(
-  keyspace: SchemaConfig.Keyspace = SchemaConfig.Keyspace.default,
+  keyspace: KeyspaceConfig = KeyspaceConfig.default,
   journalTable: String = "journal",
   metadataTable: String = "metadata",
   metaJournalTable: String = "metajournal",
@@ -14,8 +12,8 @@ final case class SchemaConfig(
   pointer2Table: String = "pointer2",
   settingTable: String = "setting",
   locksTable: String = "locks",
-  autoCreate: Boolean = true)
-
+  autoCreate: Boolean = true
+)
 
 object SchemaConfig {
 
@@ -23,17 +21,4 @@ object SchemaConfig {
 
   implicit val configReaderSchemaConfig: ConfigReader[SchemaConfig] = deriveReader
 
-
-  final case class Keyspace(
-    name: String = "journal",
-    replicationStrategy: ReplicationStrategyConfig = ReplicationStrategyConfig.Default,
-    autoCreate: Boolean = true)
-
-  object Keyspace {
-
-    val default: Keyspace = Keyspace()
-
-
-    implicit val configReaderKeyspace: ConfigReader[Keyspace] = deriveReader
-  }
 }

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
@@ -47,7 +47,7 @@ class CreateSchemaSpec extends AnyFunSuite with Matchers { self =>
   }
 
   val createKeyspace: CreateKeyspace[StateT] = new CreateKeyspace[StateT] {
-    def apply(config: SchemaConfig.Keyspace) = {
+    def apply(config: KeyspaceConfig) = {
       StateT { state =>
         val state1 = state.add(Action.CreateKeyspace)
         (state1, ())

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfigSpec.scala
@@ -18,7 +18,7 @@ class SchemaConfigSpec extends AnyFunSuite with Matchers {
   test("apply from config") {
     val config = ConfigFactory.parseURL(getClass.getResource("schema.conf"))
     val expected = SchemaConfig(
-      keyspace = SchemaConfig.Keyspace(
+      keyspace = KeyspaceConfig(
         name = "keyspace",
         replicationStrategy = ReplicationStrategyConfig.Simple(3),
         autoCreate = false),

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
@@ -67,7 +67,7 @@ object ReadEventsApp extends IOApp {
 
     val eventualCassandraConfig = EventualCassandraConfig(
       schema = SchemaConfig(
-        keyspace = SchemaConfig.Keyspace(
+        keyspace = KeyspaceConfig(
           name = "keyspace",
           autoCreate = false),
         autoCreate = false),


### PR DESCRIPTION
The idea is to allow several instances to exist, i.e. in `CreateJournalSchema` and `CreateSnapshotSchema`.