### PR TITLE
Remove dependency of `CassandraSync` on `SchemaConfig`

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraSync.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraSync.scala
@@ -74,7 +74,7 @@ object CassandraSync {
     * @param table Name of lock table to be used.
     * @param origin Identification of the code performing the lock.
     *
-    * @see cassandra.sync.CassandraSync for more details.
+    * @see [[com.evolutiongaming.cassandra.sync.CassandraSync]] for more details.
     */
   def of[F[_] : Temporal : CassandraSession](
     keyspace: KeyspaceConfig,

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -51,7 +51,7 @@ object SetupSchema {
     def createSchema(implicit cassandraSync: CassandraSync[F]) = CreateSchema(config)
 
     for {
-      cassandraSync <- CassandraSync.of[F](config, origin)
+      cassandraSync <- CassandraSync.of[F](config.keyspace, config.locksTable, origin)
       ab <- createSchema(cassandraSync)
       (schema, fresh) = ab
       settings <- SettingsCassandra.of[F](schema, origin, consistencyConfig)


### PR DESCRIPTION
The idea is to allow several instances of `SchemaConfig` to exist, i.e. `JournalSchemaConfig` and `SnapshotSchemaConfig`.