### PR TITLE
Extract consistency settings into a separate class

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraConsistencyConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraConsistencyConfig.scala
@@ -4,16 +4,16 @@ import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 import com.datastax.driver.core.ConsistencyLevel
 
-final case class ConsistencyConfig(
-  read: ConsistencyConfig.Read = ConsistencyConfig.Read.default,
-  write: ConsistencyConfig.Write = ConsistencyConfig.Write.default
+final case class CassandraConsistencyConfig(
+  read: CassandraConsistencyConfig.Read = CassandraConsistencyConfig.Read.default,
+  write: CassandraConsistencyConfig.Write = CassandraConsistencyConfig.Write.default
 )
 
-object ConsistencyConfig {
+object CassandraConsistencyConfig {
 
-  implicit val configReaderConsistencyConfig: ConfigReader[ConsistencyConfig] = deriveReader
+  implicit val configReaderConsistencyConfig: ConfigReader[CassandraConsistencyConfig] = deriveReader
 
-  val default: ConsistencyConfig = ConsistencyConfig()
+  val default: CassandraConsistencyConfig = CassandraConsistencyConfig()
 
   final case class Read(value: ConsistencyLevel = ConsistencyLevel.LOCAL_QUORUM)
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHealthCheck.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHealthCheck.scala
@@ -18,7 +18,7 @@ object CassandraHealthCheck {
 
   def of[F[_] : Temporal : LogOf](
     session: Resource[F, CassandraSession[F]],
-    consistencyConfig: ConsistencyConfig.Read
+    consistencyConfig: CassandraConsistencyConfig.Read
   ): Resource[F, CassandraHealthCheck[F]] = {
 
     val statement = for {
@@ -64,7 +64,7 @@ object CassandraHealthCheck {
 
   object Statement {
 
-    def of[F[_] : Monad : CassandraSession](consistency: ConsistencyConfig.Read): F[Statement[F]] = {
+    def of[F[_] : Monad : CassandraSession](consistency: CassandraConsistencyConfig.Read): F[Statement[F]] = {
       for {
         prepared <- "SELECT now() FROM system.local".prepare
       } yield {

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHealthCheck.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHealthCheck.scala
@@ -6,7 +6,6 @@ import cats.effect.syntax.resource._
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.{Log, LogOf, Schedule}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.util.CatsHelper._
 
 import scala.concurrent.duration._

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfig.scala
@@ -1,0 +1,33 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+import com.datastax.driver.core.ConsistencyLevel
+
+final case class ConsistencyConfig(
+  read: ConsistencyConfig.Read = ConsistencyConfig.Read.default,
+  write: ConsistencyConfig.Write = ConsistencyConfig.Write.default
+)
+
+object ConsistencyConfig {
+
+  implicit val configReaderConsistencyConfig: ConfigReader[ConsistencyConfig] = deriveReader
+
+  val default: ConsistencyConfig = ConsistencyConfig()
+
+  final case class Read(value: ConsistencyLevel = ConsistencyLevel.LOCAL_QUORUM)
+
+  object Read {
+    val default: Read = Read()
+
+    implicit val configReaderRead: ConfigReader[Read] = ConfigReader[ConsistencyLevel].map { a => Read(a) }
+  }
+
+  final case class Write(value: ConsistencyLevel = ConsistencyLevel.LOCAL_QUORUM)
+
+  object Write {
+    val default: Write = Write()
+
+    implicit val configReaderWrite: ConfigReader[Write] = ConfigReader[ConsistencyLevel].map { a => Write(a) }
+  }
+}

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -8,7 +8,6 @@ import cats.{MonadThrow, Parallel}
 import com.evolutiongaming.catshelper.{LogOf, MeasureDuration, ToTry}
 import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.eventual._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.util.CatsHelper._
 import com.evolutiongaming.scassandra.util.FromGFuture
 import com.evolutiongaming.kafka.journal.util.StreamHelper._

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -75,7 +75,7 @@ object EventualCassandra {
     schemaConfig: SchemaConfig,
     origin: Option[Origin],
     metrics: Option[EventualJournal.Metrics[F]],
-    consistencyConfig: ConsistencyConfig
+    consistencyConfig: CassandraConsistencyConfig
   ): F[EventualJournal[F]] = {
 
     for {
@@ -193,7 +193,7 @@ object EventualCassandra {
       schema: Schema,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[Statements[F]] = {
       for {
         selectRecords  <- JournalStatements.SelectRecords.of[F](schema.journal, consistencyConfig)
@@ -222,7 +222,7 @@ object EventualCassandra {
       schema: Schema,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[MetaJournalStatements[F]] = {
       of(schema.metaJournal, segmentNrsOf, segments, consistencyConfig)
     }
@@ -231,7 +231,7 @@ object EventualCassandra {
       metaJournal: TableName,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[MetaJournalStatements[F]] = {
       for {
         selectJournalHead    <- cassandra.MetaJournalStatements.SelectJournalHead.of[F](metaJournal, consistencyConfig)

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
@@ -49,8 +49,7 @@ object EventualCassandraConfig {
   implicit val configReaderEventualCassandraConfig: ConfigReader[EventualCassandraConfig] = deriveReader
 
 
-  /** @deprecated Use [[com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraConsistencyConfig]] instead */
-  @deprecated(since = "3.2.2", message = "The class was extracted to a separate class")
+  @deprecated(since = "3.2.2", message = "Use [[CassandraConsistencyConfig]] instead")
   type ConsistencyConfig = Nothing
 
 }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
@@ -49,7 +49,7 @@ object EventualCassandraConfig {
   implicit val configReaderEventualCassandraConfig: ConfigReader[EventualCassandraConfig] = deriveReader
 
 
-  /** @deprecated Use [[com.evolutiongaming.kafka.journal.eventual.cassandra.ConsistencyConfig]] instead */
+  /** @deprecated Use [[com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraConsistencyConfig]] instead */
   @deprecated(since = "3.2.2", message = "The class was extracted to a separate class")
   type ConsistencyConfig = Nothing
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
@@ -40,12 +40,17 @@ final case class EventualCassandraConfig(
       fetchSize = 1000,
       defaultIdempotence = true)),
   schema: SchemaConfig = SchemaConfig.default,
-  consistencyConfig: ConsistencyConfig = ConsistencyConfig.default)
+  consistencyConfig: CassandraConsistencyConfig = CassandraConsistencyConfig.default)
 
 object EventualCassandraConfig {
 
   val default: EventualCassandraConfig = EventualCassandraConfig()
 
   implicit val configReaderEventualCassandraConfig: ConfigReader[EventualCassandraConfig] = deriveReader
+
+
+  /** @deprecated Use [[com.evolutiongaming.kafka.journal.eventual.cassandra.ConsistencyConfig]] instead */
+  @deprecated(since = "3.2.2", message = "The class was extracted to a separate class")
+  type ConsistencyConfig = Nothing
 
 }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfig.scala
@@ -40,7 +40,7 @@ final case class EventualCassandraConfig(
       fetchSize = 1000,
       defaultIdempotence = true)),
   schema: SchemaConfig = SchemaConfig.default,
-  consistencyConfig: EventualCassandraConfig.ConsistencyConfig = EventualCassandraConfig.ConsistencyConfig.default)
+  consistencyConfig: ConsistencyConfig = ConsistencyConfig.default)
 
 object EventualCassandraConfig {
 
@@ -48,33 +48,4 @@ object EventualCassandraConfig {
 
   implicit val configReaderEventualCassandraConfig: ConfigReader[EventualCassandraConfig] = deriveReader
 
-
-  final case class ConsistencyConfig(
-    read: ConsistencyConfig.Read = ConsistencyConfig.Read.default,
-    write: ConsistencyConfig.Write = ConsistencyConfig.Write.default)
-
-  object ConsistencyConfig {
-
-    implicit val configReaderConsistencyConfig: ConfigReader[ConsistencyConfig] = deriveReader
-
-    val default: ConsistencyConfig = ConsistencyConfig()
-
-
-    final case class Read(value: ConsistencyLevel = ConsistencyLevel.LOCAL_QUORUM)
-
-    object Read {
-      val default: Read = Read()
-
-      implicit val configReaderRead: ConfigReader[Read] = ConfigReader[ConsistencyLevel].map { a => Read(a) }
-    }
-
-
-    final case class Write(value: ConsistencyLevel = ConsistencyLevel.LOCAL_QUORUM)
-
-    object Write {
-      val default: Write = Write()
-
-      implicit val configReaderWrite: ConfigReader[Write] = ConfigReader[ConsistencyLevel].map { a => Write(a) }
-    }
-  }
 }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
@@ -58,7 +58,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession : ToTry : JsonCodec.Encode](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[InsertRecords[F]] = {
 
       implicit val encodeTry: JsonCodec.Encode[Try] = JsonCodec.Encode.summon[F].mapK(ToTry.functionK)
@@ -148,7 +148,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession : ToTry : JsonCodec.Decode](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read): F[SelectRecords[F]] = {
+      consistencyConfig: CassandraConsistencyConfig.Read): F[SelectRecords[F]] = {
 
       implicit val encodeTry: JsonCodec.Decode[Try] = JsonCodec.Decode.summon[F].mapK(ToTry.functionK)
       implicit val decodeByNameByteVector: DecodeByName[ByteVector] = DecodeByName[Array[Byte]]
@@ -242,7 +242,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[DeleteTo[F]] = {
 
       val query =
@@ -280,7 +280,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Delete[F]] = {
 
       val query =

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
@@ -9,7 +9,6 @@ import com.evolutiongaming.catshelper.ToTry
 import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.eventual.EventualPayloadAndType
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.HeadersHelper._
 import com.evolutiongaming.scassandra.{DecodeByName, EncodeByName, TableName}
 import com.evolutiongaming.scassandra.syntax._

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -6,7 +6,6 @@ import cats.data.{NonEmptyList => Nel}
 import cats.syntax.all._
 import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.util.TemporalHelper._
 import com.evolutiongaming.scassandra.TableName
 import com.evolutiongaming.scassandra.syntax._
@@ -555,7 +554,7 @@ object MetaJournalStatements {
 
 
   trait DeleteExpiry[F[_]] {
-    
+
     def apply(key: Key, segment: SegmentNr): F[Unit]
   }
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -68,7 +68,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -122,7 +122,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[SelectJournalHead[F]] = {
 
       val query =
@@ -164,7 +164,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[SelectJournalPointer[F]] = {
 
       val query =
@@ -207,7 +207,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[IdByTopicAndExpireOn[F]] = {
 
       val query =
@@ -244,7 +244,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[IdByTopicAndCreated[F]] = {
 
       val query =
@@ -281,7 +281,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[IdByTopicAndSegment[F]] = {
 
       val query =
@@ -321,7 +321,7 @@ object MetaJournalStatements {
 
   object Update {
 
-    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Write
+    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Update[F]] = {
 
       val query =
@@ -367,7 +367,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[UpdateSeqNr[F]] = {
 
       val query =
@@ -414,7 +414,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[UpdateExpiry[F]] = {
 
       val query =
@@ -455,7 +455,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[UpdateDeleteTo[F]] = {
 
       val query =
@@ -494,7 +494,7 @@ object MetaJournalStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[UpdatePartitionOffset[F]] = {
       s"""
          |UPDATE ${ name.toCql }
@@ -528,7 +528,7 @@ object MetaJournalStatements {
 
   object Delete {
 
-    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Write): F[Delete[F]] = {
+    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Delete[F]] = {
 
       val query =
         s"""
@@ -562,7 +562,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[DeleteExpiry[F]] = {
 
       val query =
@@ -598,7 +598,7 @@ object MetaJournalStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[SelectIds[F]] = {
       for {
         prepared <- s"SELECT id FROM ${ name.toCql } WHERE topic = ? AND segment = ?".prepare

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
@@ -5,7 +5,6 @@ import cats.Monad
 import com.datastax.driver.core.GettableByNameData
 import com.evolutiongaming.catshelper.DataHelper._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.{DecodeRow, TableName}
 import com.evolutiongaming.scassandra.syntax._

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
@@ -35,7 +35,7 @@ object Pointer2Statements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[SelectTopics[F]] = {
 
       val query = s"""SELECT DISTINCT topic, partition FROM ${ name.toCql }""".stripMargin
@@ -76,7 +76,7 @@ object Pointer2Statements {
       }
     }
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Read): F[Select[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[Select[F]] = {
       s"""
          |SELECT created FROM ${ name.toCql }
          |WHERE topic = ?
@@ -105,7 +105,7 @@ object Pointer2Statements {
 
   object SelectOffset {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Read): F[SelectOffset[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[SelectOffset[F]] = {
 
       val query =
         s"""
@@ -138,7 +138,7 @@ object Pointer2Statements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -173,7 +173,7 @@ object Pointer2Statements {
 
   object Update {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Write): F[Update[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Update[F]] = {
 
       val query =
         s"""
@@ -207,7 +207,7 @@ object Pointer2Statements {
 
   object UpdateCreated {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Write): F[UpdateCreated[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[UpdateCreated[F]] = {
       s"""
          |UPDATE ${ name.toCql }
          |SET offset = ?, created = ?, updated = ?

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
@@ -38,7 +38,7 @@ object PointerStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -73,7 +73,7 @@ object PointerStatements {
 
   object Update {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Write): F[Update[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Update[F]] = {
 
       val query =
         s"""
@@ -118,7 +118,7 @@ object PointerStatements {
       }
     }
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Read): F[Select[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[Select[F]] = {
       s"""
          |SELECT created FROM ${ name.toCql }
          |WHERE topic = ?
@@ -147,7 +147,7 @@ object PointerStatements {
 
   object SelectOffset {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Read): F[SelectOffset[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[SelectOffset[F]] = {
 
       val query =
         s"""
@@ -180,7 +180,7 @@ object PointerStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[SelectTopics[F]] = {
 
       val query = s"""SELECT DISTINCT topic FROM ${ name.toCql }""".stripMargin

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
@@ -5,7 +5,6 @@ import cats.syntax.all._
 import com.datastax.driver.core.GettableByNameData
 import com.evolutiongaming.catshelper.DataHelper._
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.util.SkafkaHelper._
 import com.evolutiongaming.scassandra.{DecodeRow, TableName}
 import com.evolutiongaming.scassandra.syntax._

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -540,7 +540,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession](
       schema: Schema,
-      consistencyConfig: ConsistencyConfig
+      consistencyConfig: CassandraConsistencyConfig
     ): F[MetaJournalStatements[F]] = {
       of[F](schema.metaJournal, consistencyConfig)
     }
@@ -548,7 +548,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession](
       metaJournal: TableName,
-      consistencyConfig: ConsistencyConfig
+      consistencyConfig: CassandraConsistencyConfig
     ): F[MetaJournalStatements[F]] = {
 
       for {
@@ -694,7 +694,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession: ToTry: JsonCodec.Encode](
       schema: Schema,
-      consistencyConfig: ConsistencyConfig
+      consistencyConfig: CassandraConsistencyConfig
     ): F[Statements[F]] = {
       for {
         insertRecords          <- JournalStatements.InsertRecords.of[F](schema.journal, consistencyConfig.write)

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -9,7 +9,6 @@ import com.evolutiongaming.catshelper.ParallelHelper._
 import com.evolutiongaming.catshelper.{LogOf, MeasureDuration, ToTry}
 import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.eventual._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.SegmentNr.implicits._
 import com.evolutiongaming.kafka.journal.util.CatsHelper._
 import com.evolutiongaming.kafka.journal.util.Fail

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingStatements.scala
@@ -54,7 +54,7 @@ object SettingStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Read
+      consistencyConfig: CassandraConsistencyConfig.Read
     ): F[Select[F]] = {
 
       val query = s"SELECT value, timestamp, origin FROM ${ name.toCql } WHERE key = ?"
@@ -86,7 +86,7 @@ object SettingStatements {
 
   object All {
 
-    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: ConsistencyConfig.Read): F[All[F]] = {
+    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[All[F]] = {
 
       val query = s"SELECT key, value, timestamp, origin FROM ${ name.toCql }"
       for {
@@ -111,7 +111,7 @@ object SettingStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query = s"INSERT INTO ${ name.toCql } (key, value, timestamp, origin) VALUES (?, ?, ?, ?)"
@@ -137,7 +137,7 @@ object SettingStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[InsertIfEmpty[F]] = {
 
       val query = s"INSERT INTO ${ name.toCql } (key, value, timestamp, origin) VALUES (?, ?, ?, ?) IF NOT EXISTS"
@@ -167,7 +167,7 @@ object SettingStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: ConsistencyConfig.Write
+      consistencyConfig: CassandraConsistencyConfig.Write
     ): F[Delete[F]] = {
 
       val query = s"DELETE FROM ${ name.toCql } WHERE key = ?"

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingStatements.scala
@@ -7,7 +7,6 @@ import com.datastax.driver.core.{GettableByNameData, SettableData}
 import com.evolutiongaming.kafka.journal.{Origin, Setting}
 import com.evolutiongaming.kafka.journal.Setting.{Key, Value}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.scassandra.{DecodeRow, EncodeRow, TableName}
 import com.evolutiongaming.sstream.Stream

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
@@ -56,7 +56,7 @@ object SettingsCassandra {
   def of[F[_] : Monad : Parallel : Clock : CassandraSession](
     schema: Schema,
     origin: Option[Origin],
-    consistencyConfig: ConsistencyConfig
+    consistencyConfig: CassandraConsistencyConfig
   ): F[Settings[F]] = {
     for {
       statements <- Statements.of[F](schema.setting, consistencyConfig)
@@ -76,7 +76,7 @@ object SettingsCassandra {
   object Statements {
     def of[F[_] : Monad : Parallel : CassandraSession](
       table: TableName,
-      consistencyConfig: ConsistencyConfig
+      consistencyConfig: CassandraConsistencyConfig
     ): F[Statements[F]] = {
 
       val statements = (

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
@@ -4,7 +4,6 @@ import cats.effect.Clock
 import cats.syntax.all._
 import cats.{Monad, Parallel}
 import com.evolutiongaming.catshelper.ClockHelper._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.{Origin, Setting, Settings}
 import com.evolutiongaming.scassandra.TableName
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -5,7 +5,6 @@ import cats.effect.kernel.Temporal
 import cats.syntax.all._
 import cats.{MonadThrow, Parallel}
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.{Origin, Settings}
 import com.evolutiongaming.scassandra.ToCql.implicits._
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -44,7 +44,7 @@ object SetupSchema {
   def apply[F[_]: Temporal: Parallel: CassandraCluster: CassandraSession: LogOf](
     config: SchemaConfig,
     origin: Option[Origin],
-    consistencyConfig: ConsistencyConfig
+    consistencyConfig: CassandraConsistencyConfig
   ): F[Schema] = {
 
     def createSchema(implicit cassandraSync: CassandraSync[F]) = CreateSchema(config)

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfigSpec.scala
@@ -12,17 +12,17 @@ class ConsistencyConfigSpec extends AnyFunSuite with Matchers {
   test("apply from empty config") {
     ConfigSource
       .empty
-      .load[ConsistencyConfig] shouldEqual ConsistencyConfig.default.asRight
+      .load[CassandraConsistencyConfig] shouldEqual CassandraConsistencyConfig.default.asRight
   }
 
   test("apply from config") {
     val config = ConfigFactory.parseURL(getClass.getResource("consistency-config.conf"))
-    val expected = ConsistencyConfig(
-      ConsistencyConfig.Read(ConsistencyLevel.QUORUM),
-      ConsistencyConfig.Write(ConsistencyLevel.EACH_QUORUM))
+    val expected = CassandraConsistencyConfig(
+      CassandraConsistencyConfig.Read(ConsistencyLevel.QUORUM),
+      CassandraConsistencyConfig.Write(ConsistencyLevel.EACH_QUORUM))
 
     ConfigSource
       .fromConfig(config)
-      .load[ConsistencyConfig] shouldEqual expected.asRight
+      .load[CassandraConsistencyConfig] shouldEqual expected.asRight
   }
 }

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ConsistencyConfigSpec.scala
@@ -2,7 +2,6 @@ package com.evolutiongaming.kafka.journal.eventual.cassandra
 
 import cats.syntax.all._
 import com.datastax.driver.core.ConsistencyLevel
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfigSpec.scala
@@ -2,7 +2,6 @@ package com.evolutiongaming.kafka.journal.eventual.cassandra
 
 import cats.syntax.all._
 import com.datastax.driver.core.ConsistencyLevel
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraConfigSpec.scala
@@ -20,7 +20,9 @@ class EventualCassandraConfigSpec extends AnyFunSuite with Matchers {
     val expected = EventualCassandraConfig(
       retries = 1,
       segmentSize = SegmentSize.min,
-      consistencyConfig = ConsistencyConfig.default.copy(read = ConsistencyConfig.Read(ConsistencyLevel.QUORUM)))
+      consistencyConfig = CassandraConsistencyConfig.default.copy(
+        read = CassandraConsistencyConfig.Read(ConsistencyLevel.QUORUM)
+      ))
     ConfigSource.fromConfig(config).load[EventualCassandraConfig] shouldEqual expected.asRight
   }
 }

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
@@ -8,7 +8,7 @@ import cats.{Applicative, Monad, ~>}
 import com.evolutiongaming.catshelper.DataHelper._
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, FromTry, Log, MeasureDuration, MonadThrowable}
 import com.evolutiongaming.kafka.journal._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.ConsistencyConfig
+import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, ExpireOn, MetaJournalStatements, SegmentNr}
 import com.evolutiongaming.kafka.journal.util.Fail
 import com.evolutiongaming.kafka.journal.util.StreamHelper._
@@ -33,7 +33,7 @@ object PurgeExpired {
     producerConfig: ProducerConfig,
     tableName: TableName,
     metrics: Option[Metrics[F]],
-    consistencyConfig: ConsistencyConfig.Read
+    consistencyConfig: CassandraConsistencyConfig.Read
   ): Resource[F, PurgeExpired[F]] = {
 
     implicit val fromAttempt = FromAttempt.lift[F]

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
@@ -8,7 +8,7 @@ import cats.{Applicative, Monad, ~>}
 import com.evolutiongaming.catshelper.DataHelper._
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, FromTry, Log, MeasureDuration, MonadThrowable}
 import com.evolutiongaming.kafka.journal._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
+import com.evolutiongaming.kafka.journal.eventual.cassandra.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraSession, ExpireOn, MetaJournalStatements, SegmentNr}
 import com.evolutiongaming.kafka.journal.util.Fail
 import com.evolutiongaming.kafka.journal.util.StreamHelper._

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
@@ -42,8 +42,8 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
       cassandraSession: CassandraSession[F]) = {
 
       for {
-        schema   <- SetupSchema[F](config, origin, ConsistencyConfig.default)
-        settings <- SettingsCassandra.of[F](schema, origin, ConsistencyConfig.default)
+        schema   <- SetupSchema[F](config, origin, CassandraConsistencyConfig.default)
+        settings <- SettingsCassandra.of[F](schema, origin, CassandraConsistencyConfig.default)
       } yield settings
     }
 

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
@@ -8,7 +8,6 @@ import cats.effect.syntax.resource._
 import com.evolutiongaming.catshelper.{FromFuture, LogOf}
 import com.evolutiongaming.kafka.journal.CassandraSuite._
 import com.evolutiongaming.kafka.journal.IOSuite._
-import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandraConfig.ConsistencyConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra._
 import com.evolutiongaming.kafka.journal.util.ActorSystemOf
 import com.evolutiongaming.kafka.journal.util.PureConfigHelper._


### PR DESCRIPTION
The idea is to refer to it from different configuration case classes, i.e. from `EventualCassandraConfig`, `SnapshotCassandraConfig` and `CassandraHealthCheck`.