### PR TITLE
Remove dependency from `SettingsCassandra` to `Schema`

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingsCassandra.scala
@@ -54,12 +54,12 @@ object SettingsCassandra {
 
 
   def of[F[_] : Monad : Parallel : Clock : CassandraSession](
-    schema: Schema,
+    table: TableName,
     origin: Option[Origin],
     consistencyConfig: CassandraConsistencyConfig
   ): F[Settings[F]] = {
     for {
-      statements <- Statements.of[F](schema.setting, consistencyConfig)
+      statements <- Statements.of[F](table, consistencyConfig)
     } yield {
       apply(statements, origin)
     }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -53,7 +53,7 @@ object SetupSchema {
       cassandraSync <- CassandraSync.of[F](config.keyspace, config.locksTable, origin)
       ab <- createSchema(cassandraSync)
       (schema, fresh) = ab
-      settings <- SettingsCassandra.of[F](schema, origin, consistencyConfig)
+      settings <- SettingsCassandra.of[F](schema.setting, origin, consistencyConfig)
       _ <- migrate(schema, fresh, settings, cassandraSync)
     } yield schema
   }

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
@@ -43,7 +43,7 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
 
       for {
         schema   <- SetupSchema[F](config, origin, CassandraConsistencyConfig.default)
-        settings <- SettingsCassandra.of[F](schema, origin, CassandraConsistencyConfig.default)
+        settings <- SettingsCassandra.of[F](schema.setting, origin, CassandraConsistencyConfig.default)
       } yield settings
     }
 


### PR DESCRIPTION
The idea is to reuse `SettingsCassandra` in other upcoming modules, i.e. rename `Schema` to `JournalSchema` and then add `SnapshotSchema` for a new snapshotter implementation.