### PR TITLE
Fix the flakiness of DamperTest

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
@@ -263,15 +263,15 @@ object Damper {
                         case State.Idle(acquired) =>
                                                     (State.Idle(acquired = acquired - 1), ().pure[F])
                         case state: State.Busy    =>
-                                                    if (filter) {
+                          if (filter) {
                             val entries = state.entries.filter(_ != entry)
                             if (state.entries.sizeCompare(entries) == 0) {
-                                                            wakeUp(state)
+                              wakeUp(state)
                             } else {
-                                                            (state.copy(entries = entries), ().pure[F])
+                              (state.copy(entries = entries), ().pure[F])
                             }
                           } else {
-                                                        wakeUp(state)
+                            wakeUp(state)
                           }
                       }
                       .flatten
@@ -281,7 +281,7 @@ object Damper {
               ref
                 .modify {
                   case state: State.Idle =>
-                                        val acquired = state.acquired
+                    val acquired = state.acquired
                     val delay = delayOf1(acquired)
                     if (delay.length == 0) {
                       // zero delay is expected
@@ -302,7 +302,7 @@ object Damper {
                       )
                     }
                   case state: State.Busy =>
-                                        // we already have some delays in progress,
+                    // we already have some delays in progress,
                     // so we add a new one to the waiting queue
                     (
                       state.copy(entries = state.entries.enqueue(entry)),

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
@@ -127,7 +127,7 @@ object Damper {
         type Result = (State, F[Either[(Entry, Delay, WakeUp), Unit]])
 
         def idle(acquired: Acquired, effect: F[Unit]): Result = {
-                    (
+          (
             State.Idle(acquired),
             effect.map { _.asRight[(Entry, Delay, WakeUp)] }
           )
@@ -146,7 +146,7 @@ object Damper {
           *   delay scheduled, and others have zero delays.
           */
         @tailrec def idleOrBusy(acquired: Acquired, entries: Queue[Entry], effect: F[Unit]): Result = {
-            entries.dequeueOption match {
+          entries.dequeueOption match {
             case Some((entry, entries)) =>
               val delay = delayOf1(acquired)
                             if (delay.length == 0) {
@@ -245,7 +245,7 @@ object Damper {
           def acquire = {
             Deferred[F, Unit].flatMap { deferred =>
               val entry = deferred.complete(()).void
-              
+
               def await(filter: Boolean) = {
 
                 def wakeUp(state: State.Busy) = {

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Damper.scala
@@ -146,7 +146,7 @@ object Damper {
           *   delay scheduled, and others have zero delays.
           */
         @tailrec def idleOrBusy(acquired: Acquired, entries: Queue[Entry], effect: F[Unit]): Result = {
-                    entries.dequeueOption match {
+            entries.dequeueOption match {
             case Some((entry, entries)) =>
               val delay = delayOf1(acquired)
                             if (delay.length == 0) {
@@ -171,9 +171,9 @@ object Damper {
         }
 
         def start(entry: Entry, delay: Delay, wakeUp: WakeUp): F[Unit] = {
-                    (entry, delay, wakeUp)
+          (entry, delay, wakeUp)
             .tailRecM { case (entry, delay, wakeUp) =>
-              
+
               def busy(delay: Delay, acquired: Acquired, entries: Queue[Entry]) = {
                 val wakeUp = Deferred.unsafe[F, Option[Entry]]
                 (
@@ -192,7 +192,7 @@ object Damper {
 
               for {
                 start  <- Clock[F].realTime
-                                result <- wakeUp
+                result <- wakeUp
                   .get
                   .race { Temporal[F].sleep(delay) }
                 result <- result match {
@@ -249,7 +249,7 @@ object Damper {
               def await(filter: Boolean) = {
 
                 def wakeUp(state: State.Busy) = {
-                                    (
+                  (
                     state.copy(acquired = state.acquired - 1),
                     state.wakeUp.complete1(entry.some)
                   )
@@ -258,10 +258,10 @@ object Damper {
                 deferred
                   .get
                   .onCancel {
-                                        ref
+                    ref
                       .modify {
                         case State.Idle(acquired) =>
-                                                    (State.Idle(acquired = acquired - 1), ().pure[F])
+                          (State.Idle(acquired = acquired - 1), ().pure[F])
                         case state: State.Busy    =>
                           if (filter) {
                             val entries = state.entries.filter(_ != entry)

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
@@ -44,10 +44,13 @@ class DamperTest extends AsyncFunSuite with Matchers {
 
   test("cancel") {
     val result = for {
+      // start -> sleep(1.minute) -> fiber0 -> sleep(0.minutes) -> fiber1
       ref    <- Ref[IO].of(List(1.minute, 0.minutes))
       damper <- Damper.of[IO] { _ =>
         ref
           .modify {
+            // always return 1.minute
+            // after two delays above from initial Ref are consumed
             case Nil     => (Nil, 1.minute)
             case a :: as => (as, a)
           }

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.kafka.journal
 import cats.effect.{FiberIO, IO, Ref}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
-
+import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 import com.evolutiongaming.kafka.journal.IOSuite._

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
@@ -3,13 +3,14 @@ package com.evolutiongaming.kafka.journal
 import cats.effect.{FiberIO, IO, Ref}
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
+
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 import com.evolutiongaming.kafka.journal.IOSuite._
 
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
-import org.scalatest.compatible.Assertion
+
 
 class DamperTest extends AsyncFunSuite with Matchers {
 


### PR DESCRIPTION
I wrote a lot of documentation to understand how it works, and debugged it a lot.

It looks like the problem is in the test, which uses `Ref` to specify delays to be used (instead of relying on `acquired` argument).

If the delay between starting two threads is too small then concurrency race happens and `delayOf` function is called twice, when starting `fiber0` and `fiber1`.

I did not convince myself that it is a wrong behavior, so I just increased a delay in the test, so concurrent race does not happen.