### PR TITLE
Add support of #wasApplied method

### DIFF
--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHelper.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHelper.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import com.datastax.driver.core.{Duration => DurationC, _}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.util.FiniteDurationHelper._
 import com.evolutiongaming.scassandra.{DecodeByName, DecodeRow, EncodeByName, EncodeRow}
+import com.evolutiongaming.scassandra.syntax._
 import com.evolutiongaming.sstream.Stream
 
 import scala.jdk.CollectionConverters._
@@ -31,6 +32,20 @@ object CassandraHelper {
     def execute[F[_] : CassandraSession]: Stream[F, Row] = {
       CassandraSession[F].execute(self)
     }
+  }
+
+
+  implicit class RowOps(val self: Row) extends AnyVal {
+
+    /** Same as [[com.datastax.driver.core.ResultSet#wasApplied]] with some
+      * minor differences (i.e. it may throw an exception).
+      *
+      * @throws IllegalArgumentException
+      *   if `[applied]` column is not found, i.e. for non-conditional or DDL
+      *   queries.
+      */
+    def wasApplied: Boolean = self.decode[Boolean]("[applied]")
+
   }
 
 

--- a/cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHelperSpec.scala
+++ b/cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraHelperSpec.scala
@@ -1,0 +1,39 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import CassandraHelper._
+
+class CassandraHelperSpec extends AnyFunSuite {
+
+  test("wasApplied returns true when a statement was applied") {
+    val row = new RowStub {
+      override def getBool(name: String): Boolean = name match {
+        case "[applied]" => true
+        case _           => throw new IllegalArgumentException
+      }
+    }
+    assert(row.wasApplied)
+  }
+
+  test("wasApplied returns false when a statement was not applied") {
+    val row = new RowStub {
+      override def getBool(name: String): Boolean = name match {
+        case "[applied]" => false
+        case _           => throw new IllegalArgumentException
+      }
+    }
+    assert(!row.wasApplied)
+  }
+
+  test("wasApplied throws an exception when a statement was not conditional") {
+    val row = new RowStub {
+      override def getBool(name: String): Boolean = name match {
+        case "[applied]" => throw new IllegalArgumentException
+        case _           => fail("[applied] column was not requested")
+      }
+    }
+    assertThrows[IllegalArgumentException](row.wasApplied)
+  }
+
+}

--- a/cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/RowStub.scala
+++ b/cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/RowStub.scala
@@ -1,0 +1,88 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import com.datastax.driver.core.ColumnDefinitions
+import com.datastax.driver.core.LocalDate
+import com.datastax.driver.core.Row
+import com.datastax.driver.core.Token
+import com.datastax.driver.core.TupleValue
+import com.datastax.driver.core.TypeCodec
+import com.datastax.driver.core.UDTValue
+import com.google.common.reflect.TypeToken
+
+import java.math.BigInteger
+import java.net.InetAddress
+import java.nio.ByteBuffer
+import java.util.Date
+import java.util.UUID
+import java.{util => ju}
+
+class RowStub extends Row {
+
+  def notImplemented(): Nothing = sys.error("method is not implemented")
+
+  override def isNull(i: Int): Boolean = notImplemented()
+  override def getBool(i: Int): Boolean = notImplemented()
+  override def getByte(i: Int): Byte = notImplemented()
+  override def getShort(i: Int): Short = notImplemented()
+  override def getInt(i: Int): Int = notImplemented()
+  override def getLong(i: Int): Long = notImplemented()
+  override def getTimestamp(i: Int): Date = notImplemented()
+  override def getDate(i: Int): LocalDate = notImplemented()
+  override def getTime(i: Int): Long = notImplemented()
+  override def getFloat(i: Int): Float = notImplemented()
+  override def getDouble(i: Int): Double = notImplemented()
+  override def getBytesUnsafe(i: Int): ByteBuffer = notImplemented()
+  override def getBytes(i: Int): ByteBuffer = notImplemented()
+  override def getString(i: Int): String = notImplemented()
+  override def getVarint(i: Int): BigInteger = notImplemented()
+  override def getDecimal(i: Int): java.math.BigDecimal = notImplemented()
+  override def getUUID(i: Int): UUID = notImplemented()
+  override def getInet(i: Int): InetAddress = notImplemented()
+  override def getList[T <: Object](i: Int, elementsClass: Class[T]): ju.List[T] = notImplemented()
+  override def getList[T <: Object](i: Int, elementsType: TypeToken[T]): ju.List[T] = notImplemented()
+  override def getSet[T <: Object](i: Int, elementsClass: Class[T]): ju.Set[T] = notImplemented()
+  override def getSet[T <: Object](i: Int, elementsType: TypeToken[T]): ju.Set[T] = notImplemented()
+  override def getMap[K <: Object, V <: Object](i: Int, keysClass: Class[K], valuesClass: Class[V]): ju.Map[K,V] = notImplemented()
+  override def getMap[K <: Object, V <: Object](i: Int, keysType: TypeToken[K], valuesType: TypeToken[V]): ju.Map[K,V] = notImplemented()
+  override def getUDTValue(i: Int): UDTValue = notImplemented()
+  override def getTupleValue(i: Int): TupleValue = notImplemented()
+  override def getObject(i: Int): Object = notImplemented()
+  override def get[T <: Object](i: Int, targetClass: Class[T]): T = notImplemented()
+  override def get[T <: Object](i: Int, targetType: TypeToken[T]): T = notImplemented()
+  override def get[T <: Object](i: Int, codec: TypeCodec[T]): T = notImplemented()
+  override def isNull(name: String): Boolean = notImplemented()
+  override def getBool(name: String): Boolean = notImplemented()
+  override def getByte(name: String): Byte = notImplemented()
+  override def getShort(name: String): Short = notImplemented()
+  override def getInt(name: String): Int = notImplemented()
+  override def getLong(name: String): Long = notImplemented()
+  override def getTimestamp(name: String): Date = notImplemented()
+  override def getDate(name: String): LocalDate = notImplemented()
+  override def getTime(name: String): Long = notImplemented()
+  override def getFloat(name: String): Float = notImplemented()
+  override def getDouble(name: String): Double = notImplemented()
+  override def getBytesUnsafe(name: String): ByteBuffer = notImplemented()
+  override def getBytes(name: String): ByteBuffer = notImplemented()
+  override def getString(name: String): String = notImplemented()
+  override def getVarint(name: String): BigInteger = notImplemented()
+  override def getDecimal(name: String): java.math.BigDecimal = notImplemented()
+  override def getUUID(name: String): UUID = notImplemented()
+  override def getInet(name: String): InetAddress = notImplemented()
+  override def getList[T <: Object](name: String, elementsClass: Class[T]): ju.List[T] = notImplemented()
+  override def getList[T <: Object](name: String, elementsType: TypeToken[T]): ju.List[T] = notImplemented()
+  override def getSet[T <: Object](name: String, elementsClass: Class[T]): ju.Set[T] = notImplemented()
+  override def getSet[T <: Object](name: String, elementsType: TypeToken[T]): ju.Set[T] = notImplemented()
+  override def getMap[K <: Object, V <: Object](name: String, keysClass: Class[K], valuesClass: Class[V]): ju.Map[K,V] = notImplemented()
+  override def getMap[K <: Object, V <: Object](name: String, keysType: TypeToken[K], valuesType: TypeToken[V]): ju.Map[K,V] = notImplemented()
+  override def getUDTValue(name: String): UDTValue = notImplemented()
+  override def getTupleValue(name: String): TupleValue = notImplemented()
+  override def getObject(name: String): Object = notImplemented()
+  override def get[T <: Object](name: String, targetClass: Class[T]): T = notImplemented()
+  override def get[T <: Object](name: String, targetType: TypeToken[T]): T = notImplemented()
+  override def get[T <: Object](name: String, codec: TypeCodec[T]): T = notImplemented()
+  override def getColumnDefinitions(): ColumnDefinitions = notImplemented()
+  override def getToken(i: Int): Token = notImplemented()
+  override def getToken(name: String): Token = notImplemented()
+  override def getPartitionKeyToken(): Token = notImplemented()
+  
+}


### PR DESCRIPTION
This method is required to determine if conditional Cassandra statement was applied. This is needed to have an ability to use lightweight transactions and react on the results of such transactions.

The upcoming https://github.com/evolution-gaming/kafka-journal/milestone/3 milestone needs lightweight transactions to have an ability to rewrite saved snapshots without creating a new row and confirming the snapshot was actually saved.

There is also a single place in existing codebase, where conditional statement is used, but I decided against changing it, for now, to minimize the impact of this PR: https://github.com/evolution-gaming/kafka-journal/blob/1b187462b19298a9b3e595c14ae38cc43010ec87/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SettingStatements.scala#L155