### PR TITLE
Simplify CreateSchema class

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
@@ -9,6 +9,17 @@ import com.evolutiongaming.scassandra.TableName
 
 object CreateSchema {
 
+  /** Creates Cassandra schema for eventual storage of a journal.
+    *
+    * The class does not perform a schema migration if any of the tables are
+    * already present in a database, and relies on a caller to use a returned
+    * value to perfom the necessary migrations afterwards.
+    * 
+    * @return
+    *   Fully qualified table names, and `true` if all of the tables were
+    *   created from scratch, or `false` if one or more of them were already
+    *   present in a keyspace.
+    */
   def apply[F[_] : Concurrent : CassandraCluster : CassandraSession : CassandraSync : LogOf](
     config: SchemaConfig
   ): F[(Schema, MigrateSchema.Fresh)] = {
@@ -38,17 +49,17 @@ object CreateSchema {
         setting = TableName(keyspace = keyspace, table = config.settingTable)
       )
 
-      val journalStatements = JournalStatements.createTable(schema.journal)
-      val metaJournalStatements = MetaJournalStatements.createTable(schema.metaJournal)
-      val pointerStatements = PointerStatements.createTable(schema.pointer)
-      val pointer2Statements = Pointer2Statements.createTable(schema.pointer2)
-      val settingStatements = SettingStatements.createTable(schema.setting)
+      val journalStatement = JournalStatements.createTable(schema.journal)
+      val metaJournalStatement = MetaJournalStatements.createTable(schema.metaJournal)
+      val pointerStatement = PointerStatements.createTable(schema.pointer)
+      val pointer2Statement = Pointer2Statements.createTable(schema.pointer2)
+      val settingStatement = SettingStatements.createTable(schema.setting)
 
-      val journal = CreateTables.Table(config.journalTable, journalStatements)
-      val metaJournal = CreateTables.Table(config.metaJournalTable, metaJournalStatements)
-      val pointer = CreateTables.Table(config.pointerTable, pointerStatements)
-      val pointer2 = CreateTables.Table(config.pointer2Table, pointer2Statements)
-      val setting = CreateTables.Table(config.settingTable, settingStatements)
+      val journal = CreateTables.Table(config.journalTable, journalStatement)
+      val metaJournal = CreateTables.Table(config.metaJournalTable, metaJournalStatement)
+      val pointer = CreateTables.Table(config.pointerTable, pointerStatement)
+      val pointer2 = CreateTables.Table(config.pointer2Table, pointer2Statement)
+      val setting = CreateTables.Table(config.settingTable, settingStatement)
 
       val createSchema =
         if (config.autoCreate) {

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
@@ -16,12 +16,12 @@ class CreateSchemaSpec extends AnyFunSuite {
     val (database, (schema, fresh)) = createSchema.run(Database.empty).value
     assert(database.keyspaces == List("journal"))
     assert(
-      database.tables.reverse == List(
+      database.tables.sorted == List(
         "journal.journal",
+        "journal.metajournal",
         "journal.pointer",
         "journal.pointer2",
-        "journal.setting",
-        "journal.metajournal"
+        "journal.setting"
       )
     )
     assert(fresh)
@@ -37,6 +37,30 @@ class CreateSchemaSpec extends AnyFunSuite {
     val (database, (schema, fresh)) = createSchema.run(Database.empty).value
     assert(database.keyspaces == Nil)
     assert(database.tables == Nil)
+    assert(!fresh)
+    assert(schema == this.schema)
+  }
+
+  test("create part of the tables") {
+    val config = SchemaConfig.default.copy(
+      keyspace = KeyspaceConfig.default.copy(autoCreate = false)
+    )
+    val initialState = Database.empty.copy(
+      keyspaces = List("journal"),
+      tables = List("journal.setting")
+    )
+    val createSchema = CreateSchema[F](config, createKeyspace, createTables)
+    val (database, (schema, fresh)) = createSchema.run(initialState).value
+    assert(database.keyspaces == List("journal"))
+    assert(
+      database.tables.sorted == List(
+        "journal.journal",
+        "journal.metajournal",
+        "journal.pointer",
+        "journal.pointer2",
+        "journal.setting"
+      )
+    )
     assert(!fresh)
     assert(schema == this.schema)
   }

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
@@ -1,33 +1,45 @@
 package com.evolutiongaming.kafka.journal.eventual.cassandra
 
-import cats.Id
+import cats.data.State
 import cats.data.{NonEmptyList => Nel}
+import cats.syntax.all._
 import com.evolutiongaming.scassandra.TableName
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
 
-class CreateSchemaSpec extends AnyFunSuite with Matchers { self =>
+class CreateSchemaSpec extends AnyFunSuite {
+
+  type F[A] = State[Database, A]
 
   test("create keyspace and tables") {
     val config = SchemaConfig.default
-    val createSchema = CreateSchema[StateT](config, createKeyspace, createTables)
-    val initial = State.empty.copy(createTables = true)
-    val (state, (schema, fresh)) = createSchema.run(initial)
-    state shouldEqual initial.copy(actions = List(Action.CreateTables, Action.CreateKeyspace))
-    fresh shouldEqual true
-    schema shouldEqual self.schema
+    val createSchema = CreateSchema[F](config, createKeyspace, createTables)
+    val (database, (schema, fresh)) = createSchema.run(Database.empty).value
+    assert(database.keyspaces == List("journal"))
+    assert(
+      database.tables.reverse == List(
+        "journal.journal",
+        "journal.pointer",
+        "journal.pointer2",
+        "journal.setting",
+        "journal.metajournal"
+      )
+    )
+    assert(fresh)
+    assert(schema == this.schema)
   }
 
   test("not create keyspace and tables") {
-    val config = SchemaConfig.default.copy(autoCreate = false)
-    val createSchema = CreateSchema[StateT](config, createKeyspace, createTables)
-    val initial = State.empty.copy(createTables = true)
-    val (state, (schema, fresh)) = createSchema.run(initial)
-    state shouldEqual initial.copy(actions = List(Action.CreateKeyspace))
-    fresh shouldEqual false
-    schema shouldEqual self.schema
+    val config = SchemaConfig.default.copy(
+      autoCreate = false,
+      keyspace = KeyspaceConfig.default.copy(autoCreate = false)
+    )
+    val createSchema = CreateSchema[F](config, createKeyspace, createTables)
+    val (database, (schema, fresh)) = createSchema.run(Database.empty).value
+    assert(database.keyspaces == Nil)
+    assert(database.tables == Nil)
+    assert(!fresh)
+    assert(schema == this.schema)
   }
-
 
   private val schema = Schema(
     journal = TableName(keyspace = "journal", table = "journal"),
@@ -35,48 +47,64 @@ class CreateSchemaSpec extends AnyFunSuite with Matchers { self =>
     metaJournal = TableName(keyspace = "journal", table = "metajournal"),
     pointer = TableName(keyspace = "journal", table = "pointer"),
     pointer2 = TableName(keyspace = "journal", table = "pointer2"),
-    setting = TableName(keyspace = "journal", table = "setting"))
+    setting = TableName(keyspace = "journal", table = "setting")
+  )
 
-  val createTables: CreateTables[StateT] = new CreateTables[StateT] {
+  val createTables: CreateTables[F] = new CreateTables[F] {
     def apply(keyspace: String, tables: Nel[CreateTables.Table]) = {
-      StateT { state =>
-        val state1 = state.add(Action.CreateTables)
-        (state1, state.createTables)
+      val results = tables.traverse { table =>
+        assert(
+          table.queries.head.contains(
+            s"CREATE TABLE IF NOT EXISTS $keyspace.${table.name}"
+          )
+        )
+        Database.createTable(keyspace, table.name)
       }
+      results.map(_.forall(_ == true))
     }
   }
 
-  val createKeyspace: CreateKeyspace[StateT] = new CreateKeyspace[StateT] {
-    def apply(config: KeyspaceConfig) = {
-      StateT { state =>
-        val state1 = state.add(Action.CreateKeyspace)
-        (state1, ())
+  val createKeyspace: CreateKeyspace[F] = new CreateKeyspace[F] {
+    def apply(config: KeyspaceConfig) =
+      if (config.autoCreate) Database.createKeyspace(config.name)
+      else ().pure[F]
+  }
+
+  case class Database(keyspaces: List[String], tables: List[String]) {
+
+    def existsKeyspace(keyspace: String): Boolean =
+      keyspaces.contains(keyspace)
+
+    def createKeyspace(keyspace: String): Database =
+      this.copy(keyspaces = keyspace :: keyspaces)
+
+    def existsTable(keyspace: String, name: String): Boolean =
+      tables.contains(s"$keyspace.$name")
+
+    def createTable(keyspace: String, name: String): Database =
+      this.copy(tables = s"$keyspace.$name" :: tables)
+
+  }
+
+  object Database {
+
+    val empty: Database = Database(keyspaces = Nil, tables = Nil)
+
+    def createKeyspace(keyspace: String): F[Unit] =
+      State.modify(_.createKeyspace(keyspace))
+
+    def createTable(keyspace: String, name: String): F[Boolean] =
+      State { database =>
+        if (!database.existsKeyspace(keyspace)) {
+          fail(s"Keyspace '$keyspace' does not exist")
+        }
+        if (database.existsTable(keyspace, name)) {
+          (database, false)
+        } else {
+          (database.createTable(keyspace, name), true)
+        }
       }
-    }
+
   }
 
-
-  case class State(createTables: Boolean, actions: List[Action]) {
-
-    def add(action: Action): State = copy(actions = action :: actions)
-  }
-
-  object State {
-    val empty: State = State(createTables = false, actions = Nil)
-  }
-
-
-  type StateT[A] = cats.data.StateT[Id, State, A]
-
-  object StateT {
-    def apply[A](f: State => (State, A)): StateT[A] = cats.data.StateT[Id, State, A](f)
-  }
-
-
-  sealed trait Action extends Product
-
-  object Action {
-    case object CreateTables extends Action
-    case object CreateKeyspace extends Action
-  }
 }


### PR DESCRIPTION
### Main code

The big idea is to make the class simpler to read and to copy-paste, i.e. rename it to `CreateJournalSchema` and make similar `CreateSnapshotSchema`.

The current approach with functions and code reuse seems to be too complicated for the task.

### Unit tests

This PR also simplified `CreateSchemaSpec` by storing created keyspaces and tables instead of artificial `CreateTables` and `CreateKeyspace` actions, and adds a new test case, when some of the tables are created only.

Besides that it adds a new assertion checking that table creation is performed after keyspace creation, and all CQL statements start with `CREATE TABLE IF NOT EXISTS` part with a fully qualified table name.