### PR TITLE
Add ring buffer index implementation

### DIFF
--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
@@ -1,0 +1,65 @@
+package com.evolutiongaming.kafka.journal
+
+import cats.syntax.all._
+import cats.{Applicative, Id}
+import com.evolutiongaming.kafka.journal.util.Fail
+import com.evolutiongaming.kafka.journal.util.Fail.implicits._
+import com.evolutiongaming.scassandra._
+
+/** Snapshot index in a stored ring buffer */
+sealed abstract case class BufferNr(value: Int) {
+  override def toString: String = value.toString
+}
+
+object BufferNr {
+
+  val min: BufferNr = BufferNr.fromIntUnsafe(0)
+  val max: BufferNr = BufferNr.fromIntUnsafe(Int.MaxValue)
+
+  /** Create all list of buffer indicies of a given size.
+    *
+    * I.e. for `size = 3` the following list will be created:
+    * {{{
+    * List(BufferNr(0), BufferNr(1), BufferNr(2))
+    * }}}
+    */
+  def listOf(size: Int): List[BufferNr] =
+    (0 until size).toList.map(fromIntUnsafe)
+
+  private def fromIntUnsafe(value: Int): BufferNr =
+    new BufferNr(value) {}
+
+  /** Create `BufferNr` out of a value or fail it is out of an allowed range.
+    *
+    * A returned value may be reused to minimize number of allocations.
+    */
+  def of[F[_]: Applicative: Fail](value: Int): F[BufferNr] = {
+    if (value < min.value) {
+      s"invalid BufferNr of $value, it must be greater or equal to $min".fail[F, BufferNr]
+    } else if (value > max.value) {
+      s"invalid BufferNr of $value, it must be less or equal to $max".fail[F, BufferNr]
+    } else if (value === min.value) {
+      min.pure[F]
+    } else if (value === max.value) {
+      max.pure[F]
+    } else {
+      fromIntUnsafe(value).pure[F]
+    }
+  }
+
+  implicit val encodeByNameBufferNr: EncodeByName[BufferNr] =
+    EncodeByName[Int].contramap(_.value)
+  implicit val decodeByNameBufferNr: DecodeByName[BufferNr] =
+    DecodeByName[Int].map(BufferNr.of[Id])
+
+  implicit val encodeByIdxBufferNr: EncodeByIdx[BufferNr] =
+    EncodeByIdx[Int].contramap(_.value)
+  implicit val decodeByIdxBufferNr: DecodeByIdx[BufferNr] =
+    DecodeByIdx[Int].map(BufferNr.of[Id])
+
+  implicit val encodeRowSeqNr: EncodeRow[BufferNr] =
+    EncodeRow[BufferNr]("buffer_idx")
+  implicit val decodeRowSeqNr: DecodeRow[BufferNr] =
+    DecodeRow[BufferNr]("buffer_idx")
+
+}

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
@@ -16,7 +16,7 @@ object BufferNr {
   val min: BufferNr = BufferNr.fromIntUnsafe(0)
   val max: BufferNr = BufferNr.fromIntUnsafe(Int.MaxValue)
 
-  /** Create all list of buffer indicies of a given size.
+  /** Create a list of N indicies starting from [[BufferNr#min]].
     *
     * I.e. for `size = 3` the following list will be created:
     * {{{

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
@@ -7,11 +7,11 @@ import com.evolutiongaming.kafka.journal.util.Fail.implicits._
 import com.evolutiongaming.scassandra._
 
 /** Snapshot index in a stored ring buffer */
-sealed abstract case class BufferNr(value: Int) {
+private[journal] sealed abstract case class BufferNr(value: Int) {
   override def toString: String = value.toString
 }
 
-object BufferNr {
+private[journal] object BufferNr {
 
   val min: BufferNr = BufferNr.fromIntUnsafe(0)
   val max: BufferNr = BufferNr.fromIntUnsafe(Int.MaxValue)

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/BufferNr.scala
@@ -29,22 +29,18 @@ object BufferNr {
   private def fromIntUnsafe(value: Int): BufferNr =
     new BufferNr(value) {}
 
-  /** Create `BufferNr` out of a value or fail it is out of an allowed range.
+  /** Create `BufferNr` from a value or fail if it is out of an allowed range.
     *
     * A returned value may be reused to minimize number of allocations.
     */
-  def of[F[_]: Applicative: Fail](value: Int): F[BufferNr] = {
-    if (value < min.value) {
+  def of[F[_]: Applicative: Fail](value: Int): F[BufferNr] = value match {
+    case value if value < min.value =>
       s"invalid BufferNr of $value, it must be greater or equal to $min".fail[F, BufferNr]
-    } else if (value > max.value) {
+    case value if value > max.value =>
       s"invalid BufferNr of $value, it must be less or equal to $max".fail[F, BufferNr]
-    } else if (value === min.value) {
-      min.pure[F]
-    } else if (value === max.value) {
-      max.pure[F]
-    } else {
-      fromIntUnsafe(value).pure[F]
-    }
+    case min.value => min.pure[F]
+    case max.value => max.pure[F]
+    case value     => fromIntUnsafe(value).pure[F]
   }
 
   implicit val encodeByNameBufferNr: EncodeByName[BufferNr] =

--- a/snapshot/src/test/scala/com/evolutiongaming/kafka/journal/BufferNrSpec.scala
+++ b/snapshot/src/test/scala/com/evolutiongaming/kafka/journal/BufferNrSpec.scala
@@ -1,0 +1,41 @@
+package com.evolutiongaming.kafka.journal
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BufferNrSpec extends AnyFunSuite {
+
+  type F[T] = Either[String, T]
+
+  test("create BufferNr out of an Int") {
+    BufferNr.of[F](17) match {
+      case Left(message)   => fail(message)
+      case Right(bufferNr) => assert(bufferNr.value == 17)
+    }
+  }
+
+  test("fail to create negative BufferNr") {
+    BufferNr.of[F](-1) match {
+      case Left(message)   => assert(message == "invalid BufferNr of -1, it must be greater or equal to 0")
+      case Right(bufferNr) => fail(s"exception was not thrown, but got $bufferNr instead")
+    }
+  }
+
+  test("reuse BufferNr.min instance") {
+    BufferNr.of[F](0) match {
+      case Left(message)   => fail(message)
+      case Right(bufferNr) => assert(bufferNr == BufferNr.min)
+    }
+  }
+
+  test("reuse BufferNr.max instance") {
+    BufferNr.of[F](Int.MaxValue) match {
+      case Left(message)   => fail(message)
+      case Right(bufferNr) => assert(bufferNr == BufferNr.max)
+    }
+  }
+
+  test("use listOf") {
+    assert(BufferNr.listOf(3).map(_.value) == List(0, 1, 2))
+  }
+
+}


### PR DESCRIPTION
There will be several rows in Cassandra per a single snapshot primary key. Each of these rows will differ by an index, which this class is going to represent.