### PR TITLE
Add a class to pass SeqNr and snapshot payload in

### DIFF
--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/Snapshot.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/Snapshot.scala
@@ -5,9 +5,9 @@ package com.evolutiongaming.kafka.journal
   * @param seqNr
   *   Snapshot sequence number.
   * @param payload
-  *   Actual contents of a snapshot. The value is never `None` under normal circumstances.
+  *   Actual contents of a snapshot.
   */
 final case class Snapshot[A](
   seqNr: SeqNr,
-  payload: Option[A]
+  payload: A
 )

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/Snapshot.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/Snapshot.scala
@@ -1,0 +1,13 @@
+package com.evolutiongaming.kafka.journal
+
+/** Represents a snapshot to be stored or loaded from a storage.
+  *
+  * @param seqNr
+  *   Snapshot sequence number.
+  * @param payload
+  *   Actual contents of a snapshot. The value is never `None` under normal circumstances.
+  */
+final case class Snapshot[A](
+  seqNr: SeqNr,
+  payload: Option[A]
+)


### PR DESCRIPTION
The main question here is if we want to have `payload` as an `Option` or require it always to be filled.

This idea of `Option` was taken from a similar `Event` case class, but I am not sure it applies the same way to a snapshot.