### PR TITLE
Implement SnapshotRecord class

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Origin.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Origin.scala
@@ -6,6 +6,11 @@ import cats.syntax.all._
 import com.evolutiongaming.scassandra.{DecodeByName, DecodeRow, EncodeByName, EncodeRow}
 import play.api.libs.json._
 
+/** Name of the host, which produced the event or a snapshot.
+  *
+  * There is no formal requirement of which name is to be used, so it could be
+  * `/etc/hostname`, IP address or even the underlying actor system name. 
+  */
 final case class Origin(value: String) extends AnyVal {
 
   override def toString: String = value

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Origin.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Origin.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import com.evolutiongaming.scassandra.{DecodeByName, DecodeRow, EncodeByName, EncodeRow}
 import play.api.libs.json._
 
-/** Name of the host, which produced the event or a snapshot.
+/** Name of the host, which produced an event or a snapshot.
   *
   * There is no formal requirement of which name is to be used, so it could be
   * `/etc/hostname`, IP address or even the underlying actor system name. 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Version.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Version.scala
@@ -5,6 +5,7 @@ import cats.kernel.{Eq, Order}
 import com.evolutiongaming.scassandra.{DecodeByName, DecodeRow, EncodeByName, EncodeRow}
 import play.api.libs.json.{Reads, Writes}
 
+/** Version of Kafka Journal library used to persist an event or a snapshot */
 final case class Version(value: String) {
   override def toString = value
 }

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotRecord.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotRecord.scala
@@ -1,0 +1,27 @@
+package com.evolutiongaming.kafka.journal
+
+import java.time.Instant
+
+/** Snapshot to be written, or loaded from a storage, together with a metadata.
+  *
+  * Technically, if there is no Akka cluster brain split etc., there still could exists two [[SnapshotRecord]] instances
+  * per single [[Snapshot]] value. I.e. if one cluster node requests a snapshot to be persisted and then goes down, and
+  * a second node recovers before a snapshot propagates to all Cassandra nodes, and then decides to write a snapshot too.
+  *
+  * @param snapshot
+  *   Snapshot and sequence number.
+  * @param timestamp
+  *   Time when the record was created. I.e. when [[Snapshot]] came in into Kafka Journal and was wrapped into
+  *   [[SnapshotRecord]] before being written to an undelrying storage (i.e. Cassandra). This value could be useful, for
+  *   example, to analyze the lag between the last written snapshot and a current time.
+  * @param origin
+  *   The host, which produced a snapshot. See [[Origin]] for more details.
+  * @param version
+  *   The version of a library, which produced a snapshot. See [[Version]] for more details.
+  */
+final case class SnapshotRecord[A](
+  snapshot: Snapshot[A],
+  timestamp: Instant,
+  origin: Option[Origin],
+  version: Option[Version]
+)


### PR DESCRIPTION
The idea is to have a class that will be directly mapped to Cassandra columns in a table. The class is inspired by a similar `EventRecord` class. Roughly speaking it is snapshot seqNr/payload + snapshot metadata.

Once again, I am not sure if `version` and `origin` fields should be optional like they are in `EventRecord`.

It may make some sense from uniformity point of view, and for potential ability to save space if there are a lot of snapshots. But I am not sure.