### PR TITLE
Move PayloadAndType to journal module and document it

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
@@ -12,6 +12,18 @@ import scodec.bits.ByteVector
 import scala.util.Try
 
 
+/** Piece of data prepared for convenient storing into Kafka record.
+  *
+  * The usual practice is that [[PayloadAndType#payload]] will be used as a
+  * value for a Kafka record, and [[PayloadAndType#payloadType]] will get into a
+  * header.
+  *
+  * @param payload
+  *   Used to store actual payload, i.e. one or several journal events.
+  * @param payloadType
+  *   Used to determine how the contents of `payload` should be treated, i.e. if
+  *   it should be parsed as JSON.
+  */
 final case class PayloadAndType(
   payload: ByteVector,
   payloadType: PayloadType.BinaryOrJson)

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/conversions/KafkaRead.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/conversions/KafkaRead.scala
@@ -8,6 +8,11 @@ import com.evolutiongaming.kafka.journal._
 import com.evolutiongaming.kafka.journal.util.Fail
 import play.api.libs.json.JsValue
 
+/** Decode a payload loaded from Kafka.
+  *
+  * Converts a structure convenient to store in Kafka, to a structure, which is
+  * convenient to use for a business logic.
+  */
 trait KafkaRead[F[_], A] {
 
   def apply(payloadAndType: PayloadAndType): F[Events[A]]

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/conversions/KafkaWrite.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/conversions/KafkaWrite.scala
@@ -10,6 +10,11 @@ import play.api.libs.json.{JsValue, Json, Writes}
 
 import scala.annotation.tailrec
 
+/** Prepare payload for storing into Kafka.
+  *
+  * Converts a structure convenient for a business logic to a structure, which
+  * is convenient to store into Kafka.
+  */
 trait KafkaWrite[F[_], A] {
 
   def apply(events: Events[A]): F[PayloadAndType]


### PR DESCRIPTION
When documenting `PayloadAndType`, I realized that I moved it wrongly to core module, previously, because it is meant to be a payload of Kafka records and is Kafka specific.