### PR TITLE
Add scaladoc to PayloadAndType members

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
@@ -109,7 +109,7 @@ object PayloadAndType {
     * @param events
     *   List of one or multiple events.
     * @param metadata
-    *   Metadata shated by all events in the list.
+    *   Metadata shared by all events in the list.
     *
     * @tparam A
     *   Type of a JSON library used. I.e. it could be `JsValue` for Play JSON or


### PR DESCRIPTION
This PR introduces a bit more clarity into the members of `PayloadAndType` object.

The meaning and reasons behind these members was reverse engineered from https://github.com/evolution-gaming/kafka-journal/pull/144

CC: @ellentari 