### PR TITLE
Add scaladoc for ReplicatedJournal

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedJournal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedJournal.scala
@@ -14,10 +14,22 @@ import com.evolutiongaming.smetrics._
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
+/** Write-only implementation of a journal stored to eventual storage, i.e.
+  * Cassandra.
+  *
+  * This class is used to replicate events read from Kafka, hence the name.
+  *
+  * It follows a hierarchical structure, i.e., roughly speaking, it is
+  * a factory of topic-specific [[ReplicatedTopicJournal]] instances.
+  * 
+  * @see [[EventualJournal]] for a read-only counterpart of this class.
+  */
 trait ReplicatedJournal[F[_]] {
 
+  /** Select list of kafka topics previously saved into eventual storage */
   def topics: F[SortedSet[Topic]]
 
+  /** Create a topic-specific write-only journal */
   def journal(topic: Topic): Resource[F, ReplicatedTopicJournal[F]]
 }
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedJournalFlat.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedJournalFlat.scala
@@ -12,6 +12,17 @@ import scala.collection.immutable.SortedSet
 
 
 
+/** Write-only implementation of a journal stored to eventual storage, i.e.
+  * Cassandra.
+  *
+  * This class is used to replicate the events read from Kafka, hence the name.
+  *
+  * The flat interface was replaced by hierarchical [[ReplicatedJournal]] for
+  * all means and purposes except for the unit tests, and should not be used
+  * directly anymore.
+  * 
+  * @see [[EventualJournal]] for a read-only counterpart of this class.
+  */
 trait ReplicatedJournalFlat[F[_]] {
 
   def topics: F[SortedSet[Topic]]


### PR DESCRIPTION
The reason for the new scaladoc, is that I keep forgetting if it is a write or read part of a journal, and if it gets written to Kafka or Cassandra, and I have to double check every time.

An additional consideration was to understand if I need to name a new snapshotter interface similar to `ReplicatedJournalFlat`, i.e. `SnapshotStorageFlat` or not.