### PR TITLE
Add SnapshotStoreFlat interface

### DIFF
--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotSelectionCriteria.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotSelectionCriteria.scala
@@ -2,6 +2,13 @@ package com.evolutiongaming.kafka.journal
 
 import java.time.Instant
 
+/** Type safer version of `akka.persistence.SnapshotSelectionCriteria`.
+  * 
+  * The important consideration when using this class is to always use named
+  * parameters to consruct the instances of the class. Otherwise it is too
+  * easy to confuse `maxSeqNr` and `minSeqNr`, especially, given the fact,
+  * they are given in a reverse order in a constructor.
+  */
 final case class SnapshotSelectionCriteria(
   maxSeqNr: SeqNr = SeqNr.max,
   maxTimestamp: Instant = Instant.MAX,

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotSelectionCriteria.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotSelectionCriteria.scala
@@ -1,0 +1,19 @@
+package com.evolutiongaming.kafka.journal
+
+import java.time.Instant
+
+final case class SnapshotSelectionCriteria(
+  maxSeqNr: SeqNr = SeqNr.max,
+  maxTimestamp: Instant = Instant.MAX,
+  minSeqNr: SeqNr = SeqNr.min,
+  minTimestamp: Instant = Instant.MIN
+)
+
+object SnapshotSelectionCriteria {
+
+  val All: SnapshotSelectionCriteria = SnapshotSelectionCriteria()
+
+  def one(seqNr: SeqNr): SnapshotSelectionCriteria =
+    SnapshotSelectionCriteria(maxSeqNr = seqNr, minSeqNr = seqNr)
+
+}

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotStore.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotStore.scala
@@ -7,7 +7,7 @@ import com.evolutiongaming.kafka.journal.eventual.EventualPayloadAndType
   * Uses `Key` instead of `persistenceId`, similar to [[ReplicatedJournalFlat]]
   * and [[EventualJournal]].
   */
-trait SnapshotStoreFlat[F[_]] {
+trait SnapshotStore[F[_]] {
 
   /** Save snapshot for a specific key.
     *

--- a/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotStoreFlat.scala
+++ b/snapshot/src/main/scala/com/evolutiongaming/kafka/journal/SnapshotStoreFlat.scala
@@ -1,0 +1,58 @@
+package com.evolutiongaming.kafka.journal
+
+import com.evolutiongaming.kafka.journal.eventual.EventualPayloadAndType
+
+/** Snapshot storage for Kafka Journal.
+  *
+  * Uses `Key` instead of `persistenceId`, similar to [[ReplicatedJournalFlat]]
+  * and [[EventualJournal]].
+  */
+trait SnapshotStoreFlat[F[_]] {
+
+  /** Save snapshot for a specific key.
+    *
+    * @param key
+    *   Unique identifier of a journal snapshot is done for.
+    * @param snapshot
+    *   Journal snapshot including sequence number and some metadata.
+    */
+  def save(key: Key, snapshot: SnapshotRecord[EventualPayloadAndType]): F[Unit]
+
+  /** Loads a snapshot for a given key and selection criteria.
+    *
+    * If several snapshots are found using a passed selection criteria for a
+    * specific key, then the last one (i.e. with a latest `SeqNr`) is returned.
+    *
+    * @param key
+    *   Unique identifier of a journal snapshot was done for.
+    * @param criteria
+    *   Criteria to use.
+    */
+  def load(key: Key, criteria: SnapshotSelectionCriteria): F[Option[SnapshotRecord[EventualPayloadAndType]]]
+
+  /** Deletes all snapshots for a given key and selection criteria.
+    *
+    * If several snapshots are found using a passed selection criteria for a
+    * specific key, then all of them are deleted.
+    *
+    * @param key
+    *   Unique identifier of a journal snapshot was done for.
+    * @param criteria
+    *   Criteria to use.
+    */
+  def delete(key: Key, criteria: SnapshotSelectionCriteria): F[Unit]
+
+  /** Deletes a snapshot for a given key and sequence number.
+    *
+    * The method returns the same as
+    * `load(key, SnapshotSelectionCriteria.one(seqNr))`,
+    * but additional optimizations might be possible.
+    *
+    * @param key
+    *   Unique identifier of a journal snapshot was done for.
+    * @param seqNr
+    *   Sequence number to be deleted.
+    */
+  def delete(key: Key, seqNr: SeqNr): F[Unit]
+
+}


### PR DESCRIPTION
This is intended to be a main entry point to a new snapshotter.
    
The main considerations were to keep it recognizable and easy to use from a Akka Persistence Plugin, while having no dependencies on Akka itself.
 
I also tried to make it look similar to `ReplicatedJournalFlat` and `EventualJournal` for sake of uniformity of the codebase.

See also https://github.com/evolution-gaming/kafka-journal/pull/532/files#r1412205449 for a comment from @t3hnar 
