### PR TITLE
Add scaladoc for PersistentRepresentation

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
@@ -77,14 +77,20 @@ object PayloadAndType {
     * The reason this class was created is to make the logic constructing
     * [[EventJson]] in [[conversions.KafkaWrite#writeJson]] and
     * [[conversions.KafkaRead#readJson]] generic by having ability to convert
-    * from an actual business payload to serialized [[EventJsonPayloadAndType]]
-    * and back.
-    *
+    * from an actual payload to [[EventJsonPayloadAndType]] and back.
+    * 
+    * To give an example, at the time of writing the following conversions were
+    * available:
+    * ```
+    * Payload <-> EventJsonPayloadAndType[JsValue] (in kafka-journal module)
+    * Json    <-> EventJsonPayloadAndType[Json]    (in kafka-journal-circe module)
+    * ```
+    * 
     * It might be possible to express the same logic without using the class, so
     * in future it might be removed as an overall simplification.
     *
     * It usually corresponds to a single `Payload` instance if Play JSON is
-    * used, or `JsValue` instance if Circe is used instead.
+    * used, or `Json` instance if Circe is used instead.
     *
     * @param payload
     *   Serialized payload in JSON or String form.

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/SerializedMsgSerializer.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/SerializedMsgSerializer.scala
@@ -6,6 +6,10 @@ import cats.syntax.all._
 import cats.~>
 import com.evolutiongaming.serialization.{SerializedMsg, SerializedMsgConverter, SerializedMsgExt}
 
+/** Provides ability to convert an object to [[SerializedMsg]] and back.
+  * 
+  * It is a typesafe wrapper over [[SerializedMsgConverter]]
+  */
 trait SerializedMsgSerializer[F[_]] {
 
   def toMsg(a: AnyRef): F[SerializedMsg]
@@ -15,6 +19,7 @@ trait SerializedMsgSerializer[F[_]] {
 
 object SerializedMsgSerializer {
 
+  /** Create [[SerializedMsgSerializer]] from an actor system using [[SerializedMsgExt]] */
   def of[F[_] : Sync](actorSystem: ActorSystem): F[SerializedMsgSerializer[F]] = {
     for {
       converter <- Sync[F].delay { SerializedMsgExt(actorSystem) }


### PR DESCRIPTION
This improves documentation of `PersistentRepresentation` and related classes.

The logic was reverse engineered from https://github.com/evolution-gaming/kafka-journal/pull/144

CC: @ellentari 