### PR TITLE
Add `sbt-version-policy` to check for backwards compatibility issues

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
### Idea

This PR integrates  `sbt-version-policy` into a build process.

One can now run `sbt versionPolicyCheck` to validate if the upcoming version (3.3.9 at the the time of writing) is binary compatible with the previous one.

That task will fail, because the version is not backwards compatible at the moment of writing. That why the task is not integrated to CI yet.

The version is made compatible in https://github.com/evolution-gaming/kafka-journal/pull/586, which will be split to smaller PRs for an easier review (this is the first such a smaller PR).

### Details

I had to update `build.sbt` with a temporary hack which creates a separate `mima-classes` directory for journal and `eventual-cassandra` modules to make sure that `core` and `cassandra` module classes are included as in 3.3.8 version these classes were located together. That hack won't be necessary in 3.3.10 anymore.