### PR TITLE
Restore binary backwards compatibility of EventualCassandraConfig

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -49,7 +49,7 @@ object EventualCassandra {
   ): Resource[F, EventualJournal[F]] = {
 
     def journal(implicit cassandraCluster: CassandraCluster[F], cassandraSession: CassandraSession[F]) = {
-      of(config.schema, origin, metrics, config.consistencyConfig)
+      of(config.schema, origin, metrics, config.consistencyConfig.toCassandraConsistencyConfig)
     }
 
     for {

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -38,8 +38,8 @@ object ReplicatedCassandra {
   ): F[ReplicatedJournal[F]] = {
 
     for {
-      schema        <- SetupSchema[F](config.schema, origin, config.consistencyConfig)
-      statements    <- Statements.of[F](schema, config.consistencyConfig)
+      schema        <- SetupSchema[F](config.schema, origin, config.consistencyConfig.toCassandraConsistencyConfig)
+      statements    <- Statements.of[F](schema, config.consistencyConfig.toCassandraConsistencyConfig)
       log           <- LogOf[F].apply(ReplicatedCassandra.getClass)
       expiryService <- ExpiryService.of[F]
     } yield {


### PR DESCRIPTION
The idea is to restore binary backwards compatibility of `EventualCassandraConfig`.

`EventualCassandraConfig.ConsistencyConfig` is restored for that purposes and the methods are added to convert it to `CassandraConsistencyConfig` and back.

The class itself is marked as deprecated and is planned to be removed in a next non-binary-compatible release.

This is a smaller PR split from https://github.com/evolution-gaming/kafka-journal/pull/586 for easier review.