### PR TITLE
Restore backwards compatibility of classes relying on consistency level

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -49,7 +49,7 @@ object EventualCassandra {
   ): Resource[F, EventualJournal[F]] = {
 
     def journal(implicit cassandraCluster: CassandraCluster[F], cassandraSession: CassandraSession[F]) = {
-      of(config.schema, origin, metrics, config.consistencyConfig.toCassandraConsistencyConfig)
+      of(config.schema, origin, metrics, config.consistencyConfig)
     }
 
     for {
@@ -75,7 +75,7 @@ object EventualCassandra {
     schemaConfig: SchemaConfig,
     origin: Option[Origin],
     metrics: Option[EventualJournal.Metrics[F]],
-    consistencyConfig: CassandraConsistencyConfig
+    consistencyConfig: EventualCassandraConfig.ConsistencyConfig
   ): F[EventualJournal[F]] = {
 
     for {
@@ -193,7 +193,7 @@ object EventualCassandra {
       schema: Schema,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[Statements[F]] = {
       for {
         selectRecords  <- JournalStatements.SelectRecords.of[F](schema.journal, consistencyConfig)
@@ -222,7 +222,7 @@ object EventualCassandra {
       schema: Schema,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[MetaJournalStatements[F]] = {
       of(schema.metaJournal, segmentNrsOf, segments, consistencyConfig)
     }
@@ -231,7 +231,7 @@ object EventualCassandra {
       metaJournal: TableName,
       segmentNrsOf: SegmentNrsOf[F],
       segments: Segments,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[MetaJournalStatements[F]] = {
       for {
         selectJournalHead    <- cassandra.MetaJournalStatements.SelectJournalHead.of[F](metaJournal, consistencyConfig)

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalStatements.scala
@@ -58,7 +58,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession : ToTry : JsonCodec.Encode](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[InsertRecords[F]] = {
 
       implicit val encodeTry: JsonCodec.Encode[Try] = JsonCodec.Encode.summon[F].mapK(ToTry.functionK)
@@ -148,7 +148,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession : ToTry : JsonCodec.Decode](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read): F[SelectRecords[F]] = {
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read): F[SelectRecords[F]] = {
 
       implicit val encodeTry: JsonCodec.Decode[Try] = JsonCodec.Decode.summon[F].mapK(ToTry.functionK)
       implicit val decodeByNameByteVector: DecodeByName[ByteVector] = DecodeByName[Array[Byte]]
@@ -242,7 +242,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[DeleteTo[F]] = {
 
       val query =
@@ -280,7 +280,7 @@ object JournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[Delete[F]] = {
 
       val query =

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -68,7 +68,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -122,7 +122,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[SelectJournalHead[F]] = {
 
       val query =
@@ -164,7 +164,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[SelectJournalPointer[F]] = {
 
       val query =
@@ -207,7 +207,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[IdByTopicAndExpireOn[F]] = {
 
       val query =
@@ -244,7 +244,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[IdByTopicAndCreated[F]] = {
 
       val query =
@@ -281,7 +281,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[IdByTopicAndSegment[F]] = {
 
       val query =
@@ -321,7 +321,7 @@ object MetaJournalStatements {
 
   object Update {
 
-    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write
+    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[Update[F]] = {
 
       val query =
@@ -367,7 +367,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[UpdateSeqNr[F]] = {
 
       val query =
@@ -414,7 +414,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[UpdateExpiry[F]] = {
 
       val query =
@@ -455,7 +455,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[UpdateDeleteTo[F]] = {
 
       val query =
@@ -494,7 +494,7 @@ object MetaJournalStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[UpdatePartitionOffset[F]] = {
       s"""
          |UPDATE ${ name.toCql }
@@ -528,7 +528,7 @@ object MetaJournalStatements {
 
   object Delete {
 
-    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Delete[F]] = {
+    def of[F[_] : Monad : CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write): F[Delete[F]] = {
 
       val query =
         s"""
@@ -562,7 +562,7 @@ object MetaJournalStatements {
 
     def of[F[_] : Monad : CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[DeleteExpiry[F]] = {
 
       val query =
@@ -598,7 +598,7 @@ object MetaJournalStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[SelectIds[F]] = {
       for {
         prepared <- s"SELECT id FROM ${ name.toCql } WHERE topic = ? AND segment = ?".prepare

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
@@ -35,7 +35,7 @@ object Pointer2Statements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[SelectTopics[F]] = {
 
       val query = s"""SELECT DISTINCT topic, partition FROM ${ name.toCql }""".stripMargin
@@ -76,7 +76,7 @@ object Pointer2Statements {
       }
     }
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[Select[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read): F[Select[F]] = {
       s"""
          |SELECT created FROM ${ name.toCql }
          |WHERE topic = ?
@@ -105,7 +105,7 @@ object Pointer2Statements {
 
   object SelectOffset {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[SelectOffset[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read): F[SelectOffset[F]] = {
 
       val query =
         s"""
@@ -138,7 +138,7 @@ object Pointer2Statements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -173,7 +173,7 @@ object Pointer2Statements {
 
   object Update {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Update[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write): F[Update[F]] = {
 
       val query =
         s"""
@@ -207,7 +207,7 @@ object Pointer2Statements {
 
   object UpdateCreated {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[UpdateCreated[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write): F[UpdateCreated[F]] = {
       s"""
          |UPDATE ${ name.toCql }
          |SET offset = ?, created = ?, updated = ?

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/PointerStatements.scala
@@ -38,7 +38,7 @@ object PointerStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Write
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write
     ): F[Insert[F]] = {
 
       val query =
@@ -73,7 +73,7 @@ object PointerStatements {
 
   object Update {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Write): F[Update[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Write): F[Update[F]] = {
 
       val query =
         s"""
@@ -118,7 +118,7 @@ object PointerStatements {
       }
     }
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[Select[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read): F[Select[F]] = {
       s"""
          |SELECT created FROM ${ name.toCql }
          |WHERE topic = ?
@@ -147,7 +147,7 @@ object PointerStatements {
 
   object SelectOffset {
 
-    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: CassandraConsistencyConfig.Read): F[SelectOffset[F]] = {
+    def of[F[_]: Monad: CassandraSession](name: TableName, consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read): F[SelectOffset[F]] = {
 
       val query =
         s"""
@@ -180,7 +180,7 @@ object PointerStatements {
 
     def of[F[_]: Monad: CassandraSession](
       name: TableName,
-      consistencyConfig: CassandraConsistencyConfig.Read
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig.Read
     ): F[SelectTopics[F]] = {
 
       val query = s"""SELECT DISTINCT topic FROM ${ name.toCql }""".stripMargin

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -38,8 +38,8 @@ object ReplicatedCassandra {
   ): F[ReplicatedJournal[F]] = {
 
     for {
-      schema        <- SetupSchema[F](config.schema, origin, config.consistencyConfig.toCassandraConsistencyConfig)
-      statements    <- Statements.of[F](schema, config.consistencyConfig.toCassandraConsistencyConfig)
+      schema        <- SetupSchema[F](config.schema, origin, config.consistencyConfig)
+      statements    <- Statements.of[F](schema, config.consistencyConfig)
       log           <- LogOf[F].apply(ReplicatedCassandra.getClass)
       expiryService <- ExpiryService.of[F]
     } yield {
@@ -540,7 +540,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession](
       schema: Schema,
-      consistencyConfig: CassandraConsistencyConfig
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig
     ): F[MetaJournalStatements[F]] = {
       of[F](schema.metaJournal, consistencyConfig)
     }
@@ -548,7 +548,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession](
       metaJournal: TableName,
-      consistencyConfig: CassandraConsistencyConfig
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig
     ): F[MetaJournalStatements[F]] = {
 
       for {
@@ -694,7 +694,7 @@ object ReplicatedCassandra {
 
     def of[F[_]: Monad: CassandraSession: ToTry: JsonCodec.Encode](
       schema: Schema,
-      consistencyConfig: CassandraConsistencyConfig
+      consistencyConfig: EventualCassandraConfig.ConsistencyConfig
     ): F[Statements[F]] = {
       for {
         insertRecords          <- JournalStatements.InsertRecords.of[F](schema.journal, consistencyConfig.write)

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -44,7 +44,7 @@ object SetupSchema {
   def apply[F[_]: Temporal: Parallel: CassandraCluster: CassandraSession: LogOf](
     config: SchemaConfig,
     origin: Option[Origin],
-    consistencyConfig: CassandraConsistencyConfig
+    consistencyConfig: EventualCassandraConfig.ConsistencyConfig
   ): F[Schema] = {
 
     def createSchema(implicit cassandraSync: CassandraSync[F]) = CreateSchema(config)
@@ -53,7 +53,7 @@ object SetupSchema {
       cassandraSync <- CassandraSync.of[F](config.keyspace, config.locksTable, origin)
       ab <- createSchema(cassandraSync)
       (schema, fresh) = ab
-      settings <- SettingsCassandra.of[F](schema.setting, origin, consistencyConfig)
+      settings <- SettingsCassandra.of[F](schema.setting, origin, consistencyConfig.toCassandraConsistencyConfig)
       _ <- migrate(schema, fresh, settings, cassandraSync)
     } yield schema
   }


### PR DESCRIPTION
I.e. all `CassandraConsistencyConfig` arguments are rolled back to `EventualCassandraConfig.ConsistencyConfig`.

I do not plan to create non-deprecated versions of these methods as these, probably, should not used in downstream code anyway and should be made private in a next non-binary-compatible version of `kafka-journal`.

The arguments themselves will be updated as part of https://github.com/evolution-gaming/kafka-journal/issues/590.