### PR TITLE
Restore binary backwards compatibility of SchemaConfig

### DIFF
--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
@@ -72,7 +72,7 @@ object CreateSchema {
     }
 
     for {
-      _      <- createKeyspace(config.keyspace)
+      _      <- createKeyspace(config.keyspace.toKeyspaceConfig)
       result <- createTables1
     } yield result
   }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
@@ -1,10 +1,11 @@
 package com.evolutiongaming.kafka.journal.eventual.cassandra
 
+import com.evolutiongaming.scassandra.ReplicationStrategyConfig
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
 final case class SchemaConfig(
-  keyspace: KeyspaceConfig = KeyspaceConfig.default,
+  keyspace: SchemaConfig.Keyspace = SchemaConfig.Keyspace.default,
   journalTable: String = "journal",
   metadataTable: String = "metadata",
   metaJournalTable: String = "metajournal",
@@ -21,8 +22,28 @@ object SchemaConfig {
 
   implicit val configReaderSchemaConfig: ConfigReader[SchemaConfig] = deriveReader
 
+  @deprecated(since = "3.3.9", message = "Use [[KeyspaceConfig]] instead")
+  final case class Keyspace(
+    name: String = "journal",
+    replicationStrategy: ReplicationStrategyConfig = ReplicationStrategyConfig.Default,
+    autoCreate: Boolean = true) {
+    
+    def toKeyspaceConfig: KeyspaceConfig = KeyspaceConfig(
+      name = this.name,
+      replicationStrategy = this.replicationStrategy,
+      autoCreate = this.autoCreate
+    )
 
-  @deprecated(since = "3.2.2", message = "Use [[KeyspaceConfig]] instead")
-  type Keyspace = Nothing
+  }
+  
+
+  @deprecated(since = "3.3.9", message = "Use [[KeyspaceConfig]] instead")
+  object Keyspace {
+
+    val default: Keyspace = Keyspace()
+
+
+    implicit val configReaderKeyspace: ConfigReader[Keyspace] = deriveReader
+  }
 
 }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -50,7 +50,7 @@ object SetupSchema {
     def createSchema(implicit cassandraSync: CassandraSync[F]) = CreateSchema(config)
 
     for {
-      cassandraSync <- CassandraSync.of[F](config.keyspace, config.locksTable, origin)
+      cassandraSync <- CassandraSync.of[F](config.keyspace.toKeyspaceConfig, config.locksTable, origin)
       ab <- createSchema(cassandraSync)
       (schema, fresh) = ab
       settings <- SettingsCassandra.of[F](schema.setting, origin, consistencyConfig.toCassandraConsistencyConfig)

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
@@ -31,7 +31,7 @@ class CreateSchemaSpec extends AnyFunSuite {
   test("not create keyspace and tables") {
     val config = SchemaConfig.default.copy(
       autoCreate = false,
-      keyspace = KeyspaceConfig.default.copy(autoCreate = false)
+      keyspace = SchemaConfig.Keyspace.default.copy(autoCreate = false)
     )
     val createSchema = CreateSchema[F](config, createKeyspace, createTables)
     val (database, (schema, fresh)) = createSchema.run(Database.empty).value
@@ -43,7 +43,7 @@ class CreateSchemaSpec extends AnyFunSuite {
 
   test("create part of the tables") {
     val config = SchemaConfig.default.copy(
-      keyspace = KeyspaceConfig.default.copy(autoCreate = false)
+      keyspace = SchemaConfig.Keyspace.default.copy(autoCreate = false)
     )
     val initialState = Database.empty.copy(
       keyspaces = List("journal"),

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfigSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfigSpec.scala
@@ -18,7 +18,7 @@ class SchemaConfigSpec extends AnyFunSuite with Matchers {
   test("apply from config") {
     val config = ConfigFactory.parseURL(getClass.getResource("schema.conf"))
     val expected = SchemaConfig(
-      keyspace = KeyspaceConfig(
+      keyspace = SchemaConfig.Keyspace(
         name = "keyspace",
         replicationStrategy = ReplicationStrategyConfig.Simple(3),
         autoCreate = false),

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
@@ -67,7 +67,7 @@ object ReadEventsApp extends IOApp {
 
     val eventualCassandraConfig = EventualCassandraConfig(
       schema = SchemaConfig(
-        keyspace = KeyspaceConfig(
+        keyspace = SchemaConfig.Keyspace(
           name = "keyspace",
           autoCreate = false),
         autoCreate = false),


### PR DESCRIPTION
The idea is to restore binary backwards compatibility of `SchemaConfig`.

`SchemaConfig.Keyspace` is restored for that purposes and the method is added to convert it to `KeyspaceConfig`.

The class itself is marked as deprecated and is planned to be removed in a next non-binary-compatible release.

This is a smaller PR split from #586 for easier review.