### PR TITLE
Move KeyspaceConfig from eventual.cassandra to cassandra package

### DIFF
--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/KeyspaceConfig.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/KeyspaceConfig.scala
@@ -1,4 +1,4 @@
-package com.evolutiongaming.kafka.journal.eventual.cassandra
+package com.evolutiongaming.kafka.journal.cassandra
 
 import com.evolutiongaming.scassandra.ReplicationStrategyConfig
 import pureconfig.ConfigReader

--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraSync.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraSync.scala
@@ -8,6 +8,7 @@ import cats.~>
 import com.evolutiongaming.cassandra
 import com.evolutiongaming.cassandra.sync.AutoCreate
 import com.evolutiongaming.kafka.journal.Origin
+import com.evolutiongaming.kafka.journal.cassandra.KeyspaceConfig
 
 trait CassandraSync[F[_]] {
   def apply[A](fa: F[A]): F[A]

--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
@@ -3,6 +3,7 @@ package com.evolutiongaming.kafka.journal.eventual.cassandra
 import cats.syntax.all._
 import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.journal.cassandra.KeyspaceConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
 import com.evolutiongaming.scassandra.CreateKeyspaceIfNotExists
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SchemaConfig.scala
@@ -1,5 +1,6 @@
 package com.evolutiongaming.kafka.journal.eventual.cassandra
 
+import com.evolutiongaming.kafka.journal.cassandra.KeyspaceConfig
 import com.evolutiongaming.scassandra.ReplicationStrategyConfig
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader


### PR DESCRIPTION
The reasoning is the same as in
https://github.com/evolution-gaming/kafka-journal/pull/594.