### PR TITLE
Restore binary backwards compatibility for CreateKeyspace

### DIFF
--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/CreateKeyspace.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/CreateKeyspace.scala
@@ -1,10 +1,10 @@
-package com.evolutiongaming.kafka.journal.eventual.cassandra
+package com.evolutiongaming.kafka.journal.cassandra
 
 import cats.syntax.all._
 import cats.{Applicative, Monad}
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.cassandra.KeyspaceConfig
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
+import com.evolutiongaming.kafka.journal.eventual.cassandra.{CassandraCluster, CassandraSession}
 import com.evolutiongaming.scassandra.CreateKeyspaceIfNotExists
 
 trait CreateKeyspace[F[_]] {

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateKeyspace.scala
@@ -1,0 +1,29 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import cats.{Applicative, Monad}
+import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.journal.cassandra.{CreateKeyspace => CreateKeyspace2}
+
+@deprecated(since = "3.3.9", message = "Use a class from `com.evolutiongaming.kafka.journal.cassandra` (without `eventual` part) package instead")
+trait CreateKeyspace[F[_]] {
+  def apply(config: SchemaConfig.Keyspace): F[Unit]
+}
+
+@deprecated(since = "3.3.9", message = "Use a class from `com.evolutiongaming.kafka.journal.cassandra` (without `eventual` part) package instead")
+object CreateKeyspace {
+
+  private[cassandra] def apply[F[_]](createKeyspace2: CreateKeyspace2[F]): CreateKeyspace[F] =
+    config => createKeyspace2(config.toKeyspaceConfig)
+
+  def empty[F[_] : Applicative]: CreateKeyspace[F] = {
+    val createKeyspace2 = CreateKeyspace2.empty[F]
+    CreateKeyspace(createKeyspace2)
+  }
+  
+
+  def apply[F[_] : Monad : CassandraCluster : CassandraSession : LogOf]: CreateKeyspace[F] = {
+    val createKeyspace2 = CreateKeyspace2[F]
+    CreateKeyspace(createKeyspace2)
+  }
+
+}

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
@@ -72,7 +72,7 @@ object CreateSchema {
     }
 
     for {
-      _      <- createKeyspace(config.keyspace.toKeyspaceConfig)
+      _      <- createKeyspace(config.keyspace)
       result <- createTables1
     } yield result
   }

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchemaSpec.scala
@@ -89,7 +89,7 @@ class CreateSchemaSpec extends AnyFunSuite {
   }
 
   val createKeyspace: CreateKeyspace[F] = new CreateKeyspace[F] {
-    def apply(config: KeyspaceConfig) =
+    def apply(config: SchemaConfig.Keyspace) =
       if (config.autoCreate) Database.createKeyspace(config.name)
       else ().pure[F]
   }


### PR DESCRIPTION
### Details

There are now two `CreateKeyspace` classes. One in `cassandra` package and one in `eventual.cassandra` package.

### Reasoning

See the reasoning behind the approach in the following PR: #594