### PR TITLE
Enable binary compatibility check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: openjdk@1.11
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt ++${{ matrix.scala }} clean versionPolicyCheck coverage test
 
       - name: test coverage
         if: success()


### PR DESCRIPTION
This is _almost_ a final PR from https://github.com/evolution-gaming/kafka-journal/pull/586 series. It will enable checking binary compatibility during a CI build process.

There will be couple of PRs more, to clean up the things and fix a bug in a test, though. See https://github.com/evolution-gaming/kafka-journal/milestone/5 for more details.
