### PR TITLE
Fixes #603, deprecate unreliable method, fix flaky test

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Settings.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Settings.scala
@@ -17,6 +17,13 @@ trait Settings[F[_]] {
 
   def set(key: K, value: V): F[Option[Setting]]
 
+  @deprecated(
+    message =
+      "the behavior of the method might not be deterministic, " +
+      "because it uses Cassandra LWTs, while other methods do not, " +
+      "use get + set instead for a rough approximation of functionality",
+    since = "3.3.9"
+  )
   def setIfEmpty(key: K, value: V): F[Option[Setting]]
 
   def remove(key: K): F[Option[Setting]]

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
@@ -91,7 +91,7 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
   }
 
 
-  def test[F[_]: Async: Parallel: FromFuture](cassandraClusterOf: CassandraClusterOf[F],legacySettings: Boolean): F[Unit] = {
+  def test[F[_]: Async: Parallel: FromFuture](cassandraClusterOf: CassandraClusterOf[F], legacySettings: Boolean): F[Unit] = {
 
     implicit val logOf = LogOf.empty[F]
 
@@ -174,8 +174,7 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
           _ <- Sync[F].delay { a shouldEqual None }
 
           // clean up the database
-          a <- remove(setting.key)
-          _ <- Sync[F].delay { a shouldEqual setting.some }
+          _ <- remove(setting.key)
         } yield {}
       }
     } yield {
@@ -187,7 +186,7 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
   "CassandraSettings" should {
     "set, get, all, remove" in {
       // run two tests in sequence, to avoid concurrency issues
-      val program = 
+      val program =
         test[IO](cassandraClusterOf, legacySettings = false) *>
         test[IO](cassandraClusterOf, legacySettings = true)
       program.run()


### PR DESCRIPTION
This PR deprecates `setIfEmpty` method as it unreliable and is not used anymore. It is deprecated rather than removed, because API is public and it does not seem to be a good idea to break a binary API in a minor version release.

See #603 for more details.