### PR TITLE
Move `MigrateSchema` from `eventual.cassandra` to `cassandra`

### DIFF
--- a/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/MigrateSchema.scala
+++ b/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/cassandra/MigrateSchema.scala
@@ -1,4 +1,4 @@
-package com.evolutiongaming.kafka.journal.eventual.cassandra
+package com.evolutiongaming.kafka.journal.cassandra
 
 import cats.MonadThrow
 import cats.data.{NonEmptyList => Nel}
@@ -6,6 +6,7 @@ import cats.syntax.all._
 import com.evolutiongaming.kafka.journal.Settings
 import com.evolutiongaming.kafka.journal.cassandra.CassandraSync
 import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraHelper._
+import com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession
 
 import scala.util.Try
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CreateSchema.scala
@@ -5,6 +5,7 @@ import cats.data.{NonEmptyList => Nel}
 import cats.effect.Concurrent
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.LogOf
+import com.evolutiongaming.kafka.journal.cassandra.MigrateSchema
 import com.evolutiongaming.scassandra.TableName
 
 object CreateSchema {

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -5,7 +5,7 @@ import cats.effect.kernel.Temporal
 import cats.syntax.all._
 import cats.{MonadThrow, Parallel}
 import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.kafka.journal.cassandra.SettingsCassandra
+import com.evolutiongaming.kafka.journal.cassandra.{MigrateSchema, SettingsCassandra}
 import com.evolutiongaming.kafka.journal.{Origin, Settings}
 import com.evolutiongaming.scassandra.ToCql.implicits._
 


### PR DESCRIPTION
This is a new class, common to the eventual Cassandra journal storage and to a new snapshotter, so it does not make sense to keep it in the old path.

To remind: we only kept the classes at this path in `cassandra` sbt subproject for sake of binary compatibility with a previous version.

See https://github.com/evolution-gaming/kafka-journal/pull/594 and https://github.com/evolution-gaming/kafka-journal/pull/586 fore the reasons of such a movement.