### PR TITLE
Fixed flakiness of DamperTest again

### DIFF
--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/DamperTest.scala
@@ -65,17 +65,17 @@ class DamperTest extends AsyncFunSuite with Matchers {
       fiber2 <- damper.acquire.start
       _      <- assertSleeping(fiber2)
 
-      _      <- fiber1.cancel
-      _      <- fiber0.cancel
-
       delays <- ref.get
       _      <- IO {
         assert(
           delays.nonEmpty,
-          "delayOf was called more than once, the test result will not be meaningful," +
-          "consider increasing sleeping delay in `assertSleeping` to ensure the orderly" +
+          "delayOf was called more than once, the test result will not be meaningful, " +
+          "consider increasing sleeping delay in `assertSleeping` to ensure the orderly " +
           "start of fiber0, fiber1 and fiber2")
       }
+
+      _      <- fiber1.cancel
+      _      <- fiber0.cancel
 
       _      <- fiber2.joinWithNever
       _      <- damper.release


### PR DESCRIPTION
The original fix made in #555 fixed the original source of flakiness, but introduced a different one by an assertion added to a wrong place. It would check if `delayOf` was called only once, while starting the threads, when cancelation was already started.
    
The fiber cancelation would also call `delayOf` in a background, and the test would fail from time to time depending on how quickly this call propagates to a `ref` used in a test.