### PR TITLE
Expose new temporary metrics when `pointer` table is used as fallback 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,23 @@ lazy val commonSettings = Seq(
   },
 )
 
+// TODO MR remove after 3.4.1 release
+import com.typesafe.tools.mima.core.*
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    s"com.evolutiongaming.kafka.journal.eventual.ReplicatedJournal#Metrics.topicsFallback",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    s"com.evolutiongaming.kafka.journal.eventual.ReplicatedJournal#Metrics.selectOffsetFallback",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    s"com.evolutiongaming.kafka.journal.eventual.ReplicatedJournal#Metrics.selectPointerFallback",
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    s"com.evolutiongaming.kafka.journal.eventual.ReplicatedJournal#Metrics.updatePointerCreated2Fallback",
+  ),
+)
+
 val alias: Seq[sbt.Def.Setting[?]] =
   addCommandAlias("fmt", "all scalafmtAll scalafmtSbt; scalafixEnable; scalafixAll") ++
     addCommandAlias(

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Pointer2Statements.scala
@@ -201,6 +201,7 @@ object Pointer2Statements {
     }
   }
 
+  // TODO MR remove with next major release
   trait UpdateCreated[F[_]] {
 
     def apply(topic: Topic, partition: Partition, offset: Offset, created: Instant, updated: Instant): F[Unit]

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList as Nel
 import cats.effect.syntax.all.*
 import cats.effect.{Async, Ref, Resource, Sync}
 import cats.syntax.all.*
-import cats.{Applicative, Monad, Parallel}
+import cats.{Monad, Parallel}
 import com.evolutiongaming.catshelper.ParallelHelper.*
 import com.evolutiongaming.catshelper.{Log, LogOf, MeasureDuration, ToTry}
 import com.evolutiongaming.kafka.journal.eventual.*


### PR DESCRIPTION
Fixes #636