### PR TITLE
Correlate events with metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,10 +37,12 @@ lazy val commonSettings = Seq(
 
 import com.typesafe.tools.mima.core.*
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.CreateSchema.apply"),
-  ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.CreateSchema.apply"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.SetupSchema.migrate"),
-  ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.SetupSchema.migrate"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolutiongaming.kafka.journal.Journal#DataIntegrityConfig.correlateEventsWithMeta"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.Journal#DataIntegrityConfig#Implementation.copy"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.Journal#DataIntegrityConfig#Implementation.this"),
+  ProblemFilters.exclude[MissingTypesProblem]("com.evolutiongaming.kafka.journal.Journal$DataIntegrityConfig$Implementation$"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.Journal#DataIntegrityConfig#Implementation.apply"),
+  ProblemFilters.exclude[IncompatibleSignatureProblem]("com.evolutiongaming.kafka.journal.Journal#DataIntegrityConfig#Implementation.unapply"),
 )
 
 val alias: Seq[sbt.Def.Setting[?]] =

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CorrelationId.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CorrelationId.scala
@@ -1,0 +1,49 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import cats.Monad
+import cats.effect.std.UUIDGen
+import cats.syntax.all.*
+import com.evolutiongaming.scassandra.*
+import com.datastax.driver.core.{GettableByNameData, SettableData}
+
+import scala.jdk.CollectionConverters.*
+
+final case class CorrelationId(value: String) extends AnyVal {
+  override def toString: String = value
+}
+
+object CorrelationId {
+  def unsafe(value: String): CorrelationId = new CorrelationId(value)
+
+  def of[F[_]: Monad: UUIDGen]: F[CorrelationId] =
+    UUIDGen[F]
+      .randomUUID
+      .map { uuid =>
+        CorrelationId(uuid.toString)
+      }
+
+  val key = "correlation_id"
+
+  implicit val encodeByNameCorrelationId: EncodeByName[CorrelationId] = EncodeByName[String].contramap(_.value)
+  implicit val decodeByNameCorrelationId: DecodeByName[CorrelationId] = DecodeByName[String].map(CorrelationId.unsafe)
+  implicit val encodeByIdxCorrelationId: EncodeByIdx[CorrelationId]   = EncodeByIdx[String].contramap(_.value)
+  implicit val decodeByIdxCorrelationId: DecodeByIdx[CorrelationId]   = DecodeByIdx[String].map(CorrelationId.unsafe)
+
+  implicit val encodeAsPropertiesCorrelationId: EncodeRow[Option[CorrelationId]] = new EncodeRow[Option[CorrelationId]] {
+    def apply[B <: SettableData[B]](data: B, value: Option[CorrelationId]) = {
+      value
+        .map {
+          case CorrelationId(value) =>
+            data.setMap("properties", Map(key -> value).asJava, classOf[String], classOf[String])
+        }
+        .getOrElse(data)
+    }
+  }
+
+  implicit val decodePropertiesAsCorrelationId: DecodeRow[Option[CorrelationId]] = new DecodeRow[Option[CorrelationId]] {
+    def apply(data: GettableByNameData) = {
+      val properties = data.getMap("properties", classOf[String], classOf[String])
+      Option(properties.get(key)).map(CorrelationId.unsafe)
+    }
+  }
+}

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -146,7 +146,7 @@ object EventualCassandra {
     * The implementation itself is abstracted from the calls to Cassandra which
     * should be passed as part of [[Statements]] parameter.
     */
-  @deprecated("Use apply1 instead", "3.6.0")
+  @deprecated("Use apply2 instead", "3.6.0")
   def apply1[F[_]: MonadThrow](statements: Statements[F], dataIntegrity: DataIntegrityConfig): EventualJournal[F] = {
     implicit val log = Log.empty[F]
     apply2(statements, dataIntegrity)

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -200,14 +200,13 @@ object EventualCassandra {
             }
 
             if (dataIntegrity.correlateEventsWithMeta) {
-              head.correlationId.fold { events1 } {
-                case CorrelationId(fromMeta) =>
-                  events1.filter { event =>
-                    event.headers.get(CorrelationId.key) match {
-                      case None => false // meta has correlationId, event does not thus the event does not belong to the meta
-                      case Some(fromEvent) => fromMeta == fromEvent // meta and event have the same correlationId
-                    }
+              head.correlationId.fold { events1 } { fromMeta =>
+                events1.filter { event =>
+                  event.correlationId match {
+                    case None => false // meta has correlationId, event does not thus the event does not belong to the meta
+                    case Some(fromEvent) => fromMeta == fromEvent // meta and event have the same correlationId
                   }
+                }
               }
             } else {
               events1

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalHead.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalHead.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.kafka.journal.eventual.cassandra
 
 import cats.syntax.all.*
 import com.datastax.driver.core.{GettableByNameData, SettableData}
-import com.evolutiongaming.kafka.journal.{DeleteTo, PartitionOffset, SeqNr}
+import com.evolutiongaming.kafka.journal.{CorrelationId, DeleteTo, PartitionOffset, SeqNr}
 import com.evolutiongaming.scassandra.syntax.*
 import com.evolutiongaming.scassandra.{DecodeRow, EncodeRow}
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalHead.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/JournalHead.scala
@@ -15,13 +15,19 @@ import com.evolutiongaming.scassandra.{DecodeRow, EncodeRow}
   * @param segmentSize the segmentSize used to write a journal to Cassandra
   * @param seqNr the sequence number of the last event in journal stored in Cassandra
   * @param deleteTo the last sequence number deleted from journal if any
+  * @param expiry the expiry time of the journal. On expiry the journal will be purged
+  * @param correlationId unique ID of metadata entry, created once and _never_ updated. 
+  *   Used to correlate metadata with events inserted while metadata is actual: 
+  *   if purging journal will by mistake delete not all events, then after inserting new events
+  *   old ones will not be correlated with new metadata thus excluded from recovery. 
   */
 final case class JournalHead(
   partitionOffset: PartitionOffset,
   segmentSize: SegmentSize,
   seqNr: SeqNr,
-  deleteTo: Option[DeleteTo] = none,
-  expiry: Option[Expiry]     = none,
+  deleteTo: Option[DeleteTo]           = none,
+  expiry: Option[Expiry]               = none,
+  correlationId: Option[CorrelationId] = none,
 )
 
 object JournalHead {
@@ -35,6 +41,7 @@ object JournalHead {
           seqNr           = row.decode[SeqNr],
           deleteTo        = row.decode[Option[DeleteTo]]("delete_to"),
           expiry          = row.decode[Option[Expiry]],
+          correlationId   = row.decode[Option[CorrelationId]],
         )
       }
   }
@@ -48,6 +55,7 @@ object JournalHead {
           .encode(value.seqNr)
           .encodeSome(value.deleteTo)
           .encode(value.expiry)
+          .encode(value.correlationId)
       }
     }
   }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -130,7 +130,7 @@ object MetaJournalStatements {
 
       val query =
         s"""
-           |SELECT partition, offset, segment_size, seq_nr, delete_to, expire_after, expire_on FROM ${name.toCql}
+           |SELECT partition, offset, segment_size, seq_nr, delete_to, expire_after, expire_on, properties FROM ${name.toCql}
            |WHERE id = ?
            |AND topic = ?
            |AND segment = ?

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -104,7 +104,7 @@ object MetaJournalStatements {
               .bind()
               .encode(key)
               .encode(segment)
-              .put(journalHead)
+              .update(journalHead)
               .encode("created", created)
               .encode("created_date", created.toLocalDate(ZoneOffset.UTC))
               .encode("updated", updated)
@@ -150,7 +150,7 @@ object MetaJournalStatements {
           } yield for {
             row <- row
           } yield {
-            row.take[JournalHead]
+            row.decode[JournalHead]
           }
         }
     }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -104,7 +104,7 @@ object MetaJournalStatements {
               .bind()
               .encode(key)
               .encode(segment)
-              .encode(journalHead)
+              .put(journalHead)
               .encode("created", created)
               .encode("created_date", created.toLocalDate(ZoneOffset.UTC))
               .encode("updated", updated)
@@ -150,7 +150,7 @@ object MetaJournalStatements {
           } yield for {
             row <- row
           } yield {
-            row.decode[JournalHead]
+            row.take[JournalHead]
           }
         }
     }

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -354,11 +354,8 @@ object ReplicatedCassandra {
                               ): F[Unit] = {
 
                                 def insert(segment: Segment, events: Nel[EventRecord[EventualPayloadAndType]]) = {
-                                  val events1 = journalHead.correlationId.fold { events } {
-                                    case CorrelationId(cid) =>
-                                      events.map { event =>
-                                        event.copy(headers = event.headers + { CorrelationId.key -> cid })
-                                      }
+                                  val events1 = journalHead.correlationId.fold { events } { cid =>
+                                    events.map { _.withCorrelationId(cid) }
                                   }
 
                                   for {

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.kafka.journal.eventual.cassandra
 
 import cats.data.NonEmptyList as Nel
+import cats.effect.std.UUIDGen
 import cats.effect.syntax.all.*
 import cats.effect.{Async, Ref, Resource, Sync}
 import cats.syntax.all.*
@@ -50,7 +51,17 @@ object ReplicatedCassandra {
     }
   }
 
+  @deprecated("use `apply1` instead", "3.6.0")
   def apply[F[_]: Sync: Parallel: Fail](
+    segmentSizeDefault: SegmentSize,
+    segmentNrsOf: SegmentNrsOf[F],
+    statements: Statements[F],
+    expiryService: ExpiryService[F],
+  ): ReplicatedJournal[F] = {
+    apply1(segmentSizeDefault, segmentNrsOf, statements, expiryService)
+  }
+
+  def apply1[F[_]: Sync: Parallel: Fail: UUIDGen](
     segmentSizeDefault: SegmentSize,
     segmentNrsOf: SegmentNrsOf[F],
     statements: Statements[F],
@@ -59,7 +70,7 @@ object ReplicatedCassandra {
     applyWithTempMetrics(segmentSizeDefault, segmentNrsOf, statements, expiryService, None, None)
   }
 
-  private def applyWithTempMetrics[F[_]: Sync: Parallel: Fail](
+  private def applyWithTempMetrics[F[_]: Sync: Parallel: Fail: UUIDGen](
     segmentSizeDefault: SegmentSize,
     segmentNrsOf: SegmentNrsOf[F],
     statements: Statements[F],

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandra.scala
@@ -13,7 +13,7 @@ import com.evolutiongaming.kafka.journal.eventual.cassandra.ReplicatedCassandra.
 import com.evolutiongaming.kafka.journal.eventual.cassandra.SegmentNr.implicits.*
 import com.evolutiongaming.kafka.journal.util.CatsHelper.*
 import com.evolutiongaming.kafka.journal.util.Fail
-import com.evolutiongaming.kafka.journal.{cassandra as _, *}
+import com.evolutiongaming.kafka.journal.{CorrelationId, cassandra as _, *}
 import com.evolutiongaming.scassandra.TableName
 import com.evolutiongaming.skafka.{Offset, Partition, Topic}
 

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Segment.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/Segment.scala
@@ -14,6 +14,9 @@ object Segment {
 
   implicit class SegmentOps(val self: Segment) extends AnyVal {
 
+    /**
+      * Returns the next segment `seqNr` belongs to it, otherwise `None`.
+      */
     def next(seqNr: SeqNr): Option[Segment] = {
       val segmentNr = SegmentNr(seqNr, self.size)
       if (segmentNr === self.nr) none

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraSpec.scala
@@ -394,7 +394,7 @@ object EventualCassandraSpec {
       selectTopics2,
     )
 
-    ReplicatedCassandra(segmentSize, segmentNrsOf, statements, ExpiryService(ZoneOffset.UTC))
+    ReplicatedCassandra.apply1(segmentSize, segmentNrsOf, statements, ExpiryService(ZoneOffset.UTC))
   }
 
   def journalsOf(

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraSpec.scala
@@ -4,6 +4,7 @@ import cats.Parallel
 import cats.effect.IO
 import cats.implicits.*
 import com.evolutiongaming.catshelper.DataHelper.*
+import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.journal.*
 import com.evolutiongaming.kafka.journal.Journal.DataIntegrityConfig
 import com.evolutiongaming.kafka.journal.eventual.*
@@ -113,6 +114,8 @@ object EventualCassandraSpec {
 
   implicit val parallelStateT: Parallel[StateT] = Parallel.identity[StateT]
 
+  implicit val log: Log[StateT] = Log.empty[StateT]
+
   def eventualJournalOf(segmentNrsOf: SegmentNrsOf[StateT], segments: Segments): EventualJournal[StateT] = {
 
     val selectRecords = new JournalStatements.SelectRecords[StateT] {
@@ -145,7 +148,7 @@ object EventualCassandraSpec {
 
     val statements = EventualCassandra.Statements(selectRecords, metaJournalStatements, selectOffset, selectOffset2)
 
-    EventualCassandra.apply1[StateT](statements, DataIntegrityConfig.Default)
+    EventualCassandra.apply2[StateT](statements, DataIntegrityConfig.Default)
   }
 
   def replicatedJournalOf(

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraTest.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraTest.scala
@@ -5,6 +5,7 @@ import cats.data.NonEmptyList as Nel
 import cats.effect.Concurrent
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.DataHelper.*
+import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.journal.*
 import com.evolutiongaming.kafka.journal.Journal.DataIntegrityConfig
 import com.evolutiongaming.kafka.journal.eventual.EventualPayloadAndType
@@ -51,6 +52,8 @@ class EventualCassandraTest extends AnyFunSuite with Matchers {
     segmentSize <- List(SegmentSize.min, SegmentSize.default, SegmentSize.max)
     segments    <- List(Segments.min, Segments.old)
   } {
+    implicit val log: Log[StateT] = Log.empty[StateT]
+
     val config = new DataIntegrityConfig {
       override def seqNrUniqueness         = true
       override def correlateEventsWithMeta = true
@@ -58,7 +61,7 @@ class EventualCassandraTest extends AnyFunSuite with Matchers {
     val segmentOf    = SegmentOf[Id](segments)
     val segmentNrsOf = SegmentNrsOf[StateT](first = segments, Segments.default)
     val statements   = statementsOf(segmentNrsOf, Segments.default)
-    val journal      = EventualCassandra.apply1(statements, config)
+    val journal      = EventualCassandra.apply2(statements, config)
 
     val suffix = s"segmentSize: $segmentSize, segments: $segments"
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/CorrelationId.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/CorrelationId.scala
@@ -1,4 +1,4 @@
-package com.evolutiongaming.kafka.journal.eventual.cassandra
+package com.evolutiongaming.kafka.journal
 
 import cats.Monad
 import cats.effect.std.UUIDGen

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/EventRecord.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/EventRecord.scala
@@ -26,6 +26,12 @@ final case class EventRecord[A](
   def partition: Partition = partitionOffset.partition
 
   def pointer: JournalPointer = JournalPointer(partitionOffset, event.seqNr)
+
+  def correlationId: Option[CorrelationId] = headers.get(CorrelationId.key).map(CorrelationId.unsafe)
+
+  def withCorrelationId(cid: CorrelationId): EventRecord[A] = {
+    copy(headers = headers.updated(CorrelationId.key, cid.value))
+  }
 }
 
 object EventRecord {

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/EventRecord.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/EventRecord.scala
@@ -32,6 +32,10 @@ final case class EventRecord[A](
   def withCorrelationId(cid: CorrelationId): EventRecord[A] = {
     copy(headers = headers.updated(CorrelationId.key, cid.value))
   }
+
+  def withoutCorrelationId: EventRecord[A] = {
+    copy(headers = headers - CorrelationId.key)
+  }
 }
 
 object EventRecord {

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
@@ -15,6 +15,11 @@ import pureconfig.generic.semiauto.*
 
 import scala.concurrent.duration.*
 
+/**
+  * Client-side API for Kafka Journal, for Replicator-side API check [[ReplicatedJournal]].
+  * 
+  * Supports storing & deleting events, purging journals (actor's lifetime) and reading events (actor's recovery).
+  */
 trait Journal[F[_]] {
 
   def append[A](

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
@@ -333,14 +333,29 @@ object Journal {
   }
 
   trait DataIntegrityConfig {
+
+    /**
+      * If true then duplicated [[SeqNr]] in events will cause [[JournalError]] `Data integrity violated`
+      */
     def seqNrUniqueness: Boolean
+
+    /**
+      * If true then events with [[CorrelationId]] different from one in metadata will be filtered out
+      */
+    def correlateEventsWithMeta: Boolean
   }
 
   object DataIntegrityConfig {
 
-    private case class Implementation(seqNrUniqueness: Boolean) extends DataIntegrityConfig
+    private case class Implementation(
+      seqNrUniqueness: Boolean,
+      correlateEventsWithMeta: Boolean,
+    ) extends DataIntegrityConfig
 
-    val Default: DataIntegrityConfig = Implementation(seqNrUniqueness = true)
+    val Default: DataIntegrityConfig = Implementation(
+      seqNrUniqueness         = true,
+      correlateEventsWithMeta = false,
+    )
 
     implicit val configReaderDataIntegrityConfig: ConfigReader[DataIntegrityConfig] =
       deriveReader[Implementation].map(a => a: DataIntegrityConfig)

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/StreamActionRecords.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/StreamActionRecords.scala
@@ -14,8 +14,8 @@ trait StreamActionRecords[F[_]] {
     *
     * @param offset
     *   The offset to start the reading from. If `None` then reading will start
-    *   from the beginning, which could either be the begining of Kafka topic
-    *   partion, or another offset, if the stream implementation limits it to
+    *   from the beginning, which could either be the beginning of Kafka topic
+    *   partition, or another offset, if the stream implementation limits it to
     *   some newer offset.
     */
   def apply(offset: Option[Offset]): Stream[F, ActionRecord[Action.User]]

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/EventualJournal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/EventualJournal.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 
 /** Reader of the replicated journal (Cassandra by default).
   *
-  * This allows to access the data replicated from Kafka to Cassandara. Note,
+  * This allows to access the data replicated from Kafka to Cassandra. Note,
   * that all the methods of this class have eventual nature, i.e. there could be
   * newer events already in Kafka, but not yet replicated to Cassandra.
   *

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedKeyJournal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedKeyJournal.scala
@@ -10,6 +10,12 @@ import com.evolutiongaming.skafka.{Offset, Partition, Topic}
 
 import java.time.Instant
 
+/**
+  * Write-only implementation of a journal stored to eventual storage, i.e. Cassandra. 
+  * The interface provides actions against a _single key_ thus the name.
+  * 
+  * Alternative API provided by [[ReplicatedJournalFlat]] is more suitable for general use.
+  */
 trait ReplicatedKeyJournal[F[_]] {
 
   def append(

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedPartitionJournal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedPartitionJournal.scala
@@ -10,6 +10,12 @@ import com.evolutiongaming.skafka.{Offset, Partition, Topic}
 
 import java.time.Instant
 
+/**
+  * Write-only implementation of a journal stored to eventual storage, i.e. Cassandra.
+  * The interface provides actions against a _single Kafka partition_ thus the name.
+  * 
+  * Alternative API provided by [[ReplicatedJournalFlat]] is more suitable for general use.
+  */
 trait ReplicatedPartitionJournal[F[_]] {
 
   def offsets: ReplicatedPartitionJournal.Offsets[F]

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedTopicJournal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/eventual/ReplicatedTopicJournal.scala
@@ -8,6 +8,12 @@ import com.evolutiongaming.catshelper.{BracketThrowable, Log, MeasureDuration, M
 import com.evolutiongaming.kafka.journal.*
 import com.evolutiongaming.skafka.{Partition, Topic}
 
+/**
+  * Write-only implementation of a journal stored to eventual storage, i.e. Cassandra.
+  * The interface provides actions against a _single Kafka topic_ thus the name.
+  * 
+  * Alternative API provided by [[ReplicatedJournalFlat]] is more suitable for general use.
+  */
 trait ReplicatedTopicJournal[F[_]] {
 
   def apply(partition: Partition): Resource[F, ReplicatedPartitionJournal[F]]

--- a/persistence/src/test/resources/akka/persistence/kafka/journal/kafka-journal.conf
+++ b/persistence/src/test/resources/akka/persistence/kafka/journal/kafka-journal.conf
@@ -18,5 +18,6 @@ consumer-pool {
   idle-timeout = 1s
 }
 data-integrity {
-  seq-nr-uniqueness =  true
+  seq-nr-uniqueness = true
+  correlate-events-with-meta = false
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val `kafka-launcher`           = "com.evolutiongaming"    %% "kafka-launcher"                 % "0.2.0"
   val `testcontainers-cassandra` = "com.dimafeng"           %% "testcontainers-scala-cassandra" % "0.41.4"
   val hostname                   = "com.evolutiongaming"    %% "hostname"                       % "0.2.0"
-  val scassandra                 = "com.evolutiongaming"    %% "scassandra"                     % "5.2.2-SNAPSHOT"
+  val scassandra                 = "com.evolutiongaming"    %% "scassandra"                     % "5.3.0"
   val `cassandra-sync`           = "com.evolutiongaming"    %% "cassandra-sync"                 % "3.0.0"
   val `cats-helper`              = "com.evolutiongaming"    %% "cats-helper"                    % "3.11.0"
   val random                     = "com.evolutiongaming"    %% "random"                         % "1.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val `kafka-launcher`           = "com.evolutiongaming"    %% "kafka-launcher"                 % "0.2.0"
   val `testcontainers-cassandra` = "com.dimafeng"           %% "testcontainers-scala-cassandra" % "0.41.4"
   val hostname                   = "com.evolutiongaming"    %% "hostname"                       % "0.2.0"
-  val scassandra                 = "com.evolutiongaming"    %% "scassandra"                     % "5.2.1"
+  val scassandra                 = "com.evolutiongaming"    %% "scassandra"                     % "5.2.2-SNAPSHOT"
   val `cassandra-sync`           = "com.evolutiongaming"    %% "cassandra-sync"                 % "3.0.0"
   val `cats-helper`              = "com.evolutiongaming"    %% "cats-helper"                    % "3.11.0"
   val random                     = "com.evolutiongaming"    %% "random"                         % "1.0.0"

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/IntegrationSuite.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/IntegrationSuite.scala
@@ -15,6 +15,10 @@ import com.evolutiongaming.smetrics.CollectorRegistry
 import com.github.dockerjava.api.model.{ExposedPort, HostConfig, PortBinding, Ports}
 import com.typesafe.config.ConfigFactory
 
+/**
+  * IntegrationSuite is a class that provides a way to start the necessary services for the integration tests:
+  * Cassandra, Kafka, and Replicator.  
+  */
 object IntegrationSuite {
 
   def startF[F[_]: Async: ToFuture: LogOf: MeasureDuration: FromTry: ToTry: Fail](

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.4.3-SNAPSHOT"
+ThisBuild / version := "3.6.0"


### PR DESCRIPTION
### Problem
KJ can be in inconsistent state when (after purging) meta from `metajournal` was deleted while events from `journal` left behind. By itself its not an issue, but after the journal used again and new meta inserted - then old events will be awailable (probably with duplicated `seqNr`).

### Solution 
Create correlation between meta and events that belong to it, i. e. were created while the meta was present. Then, on reading journal, only events that correlate with meta must be used.

### Implementation 
Add `CorrelationId` to `journal.headers` and `metajournal.properties`. In appending events `CorrelationId` from meta will be used, if meta not present yet - new `CorrelationId` generated. On reading compare `CorrelationId` from meta and event ignoring events with another value. `CorrelationId` is optional value thus validation takes place only if its present in meta.