### PR TITLE
Add meta_record_id into journal & record_id metajournal tables for gaining correlation between them

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,16 @@ lazy val commonSettings = Seq(
   },
 )
 
-//import com.typesafe.tools.mima.core.*
-//ThisBuild / mimaBinaryIssueFilters ++= Seq(
-//)
+import com.typesafe.tools.mima.core.*
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.evolutiongaming.kafka.journal.Journal$DataIntegrityConfig"),
+  ProblemFilters.exclude[MissingClassProblem]("com.evolutiongaming.kafka.journal.Journal$DataIntegrityConfig$*"),
+  ProblemFilters.exclude[IncompatibleSignatureProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.JournalHead.*"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.JournalHead.*"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.evolutiongaming.kafka.journal.replicator.TopicReplicatorMetrics.*"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolutiongaming.kafka.journal.replicator.TopicReplicatorMetrics.*"),
+  ProblemFilters.exclude[IncompatibleSignatureProblem]("com.evolutiongaming.kafka.journal.eventual.cassandra.JournalStatements#*"),
+)
 
 val alias: Seq[sbt.Def.Setting[?]] =
   addCommandAlias("fmt", "all scalafmtAll scalafmtSbt; scalafixEnable; scalafixAll") ++

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/MetaJournalStatements.scala
@@ -32,6 +32,7 @@ object MetaJournalStatements {
       |updated TIMESTAMP,
       |expire_after DURATION,
       |expire_on DATE,
+      |record_id UUID,
       |origin TEXT,
       |properties MAP<TEXT,TEXT>,
       |metadata TEXT,
@@ -47,6 +48,10 @@ object MetaJournalStatements {
       |""".stripMargin
 
     Nel.of(table, createdDateIdx, expireOnIdx)
+  }
+
+  def addRecordId(table: TableName): String = {
+    s"ALTER TABLE ${table.toCql} ADD record_id UUID"
   }
 
   trait Insert[F[_]] {
@@ -84,9 +89,10 @@ object MetaJournalStatements {
            |updated,
            |expire_after,
            |expire_on,
+           |record_id,
            |origin,
            |properties)
-           |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            |""".stripMargin
 
       query
@@ -130,7 +136,7 @@ object MetaJournalStatements {
 
       val query =
         s"""
-           |SELECT partition, offset, segment_size, seq_nr, delete_to, expire_after, expire_on FROM ${name.toCql}
+           |SELECT partition, offset, segment_size, seq_nr, delete_to, expire_after, expire_on, record_id FROM ${name.toCql}
            |WHERE id = ?
            |AND topic = ?
            |AND segment = ?

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/RecordId.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/RecordId.scala
@@ -1,0 +1,41 @@
+package com.evolutiongaming.kafka.journal.eventual.cassandra
+
+import cats.effect.Sync
+import cats.effect.std.UUIDGen
+import cats.syntax.all.*
+import com.datastax.driver.core.{GettableByNameData, SettableData}
+import com.evolutiongaming.scassandra.*
+
+import java.util.UUID
+
+/**
+  * ID that represents unique record _instance_ in a Cassandra table.
+  * 
+  * Each table record has a private key that is used to identify the record in the table.
+  * The record can be later deleted and inserted again, so same private key is used.
+  * [[RecordId]] is used to differentiate between different record instances, so
+  * that deleted record and recreated one are not considered the same while sharing
+  * same private key.
+  */
+final case class RecordId(value: UUID) extends AnyVal {
+  override def toString: String = value.toString()
+}
+
+object RecordId {
+
+  private[cassandra] def unsafe: RecordId = new RecordId(UUID.randomUUID())
+
+  def of[F[_]: Sync: UUIDGen]: F[RecordId] =
+    Sync[F].defer {
+      UUIDGen[F]
+        .randomUUID
+        .map { uuid => RecordId(uuid) }
+    }
+
+  implicit val recordIdDecodeByName: DecodeByName[RecordId] = new DecodeByName[RecordId] {
+    override def apply(data: GettableByNameData, name: String): RecordId = RecordId(data.getUUID(name))
+  }
+  implicit val recordIdEncodeByName: EncodeByName[RecordId] = new EncodeByName[RecordId] {
+    override def apply[B <: SettableData[B]](data: B, name: String, recordId: RecordId): B = data.setUUID(name, recordId.value)
+  }
+}

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchema.scala
@@ -41,7 +41,13 @@ object SetupSchema {
     def createPointer2: String =
       Pointer2Statements.createTable(schema.pointer2)
 
-    Nel.of(addHeaders, addVersion, dropMetadata, createPointer2)
+    def journalAddMetaRecordId: String =
+      JournalStatements.addMetaRecordId(schema.journal)
+
+    def metaAddRecordId: String =
+      MetaJournalStatements.addRecordId(schema.metaJournal)
+
+    Nel.of(addHeaders, addVersion, dropMetadata, createPointer2, journalAddMetaRecordId, metaAddRecordId)
 
   }
 

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchemaSpec.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/SetupSchemaSpec.scala
@@ -25,10 +25,10 @@ class SetupSchemaSpec extends AnyFunSuite with Matchers {
       .run(initial)
       .get
     state shouldEqual initial.copy(
-      version = "3".some,
+      version = "5".some,
       actions = List(
         Action.SyncEnd,
-        Action.SetSetting("schema-version", "3"),
+        Action.SetSetting("schema-version", "5"),
         Action.GetSetting("schema-version"),
         Action.SyncStart,
         Action.GetSetting("schema-version"),
@@ -42,9 +42,13 @@ class SetupSchemaSpec extends AnyFunSuite with Matchers {
       .run(initial)
       .get
     state shouldEqual initial.copy(
-      version = "3".some,
+      version = "5".some,
       actions = List(
         Action.SyncEnd,
+        Action.SetSetting("schema-version", "5"),
+        Action.Query,
+        Action.SetSetting("schema-version", "4"),
+        Action.Query,
         Action.SetSetting("schema-version", "3"),
         Action.Query,
         Action.SetSetting("schema-version", "2"),
@@ -66,9 +70,13 @@ class SetupSchemaSpec extends AnyFunSuite with Matchers {
       .run(initial)
       .get
     state shouldEqual initial.copy(
-      version = "3".some,
+      version = "5".some,
       actions = List(
         Action.SyncEnd,
+        Action.SetSetting("schema-version", "5"),
+        Action.Query,
+        Action.SetSetting("schema-version", "4"),
+        Action.Query,
         Action.SetSetting("schema-version", "3"),
         Action.Query,
         Action.SetSetting("schema-version", "2"),
@@ -83,7 +91,7 @@ class SetupSchemaSpec extends AnyFunSuite with Matchers {
   }
 
   test("not migrate") {
-    val initial = State.empty.copy(version = "3".some)
+    val initial = State.empty.copy(version = "5".some)
     val (state, _) = migrate(fresh = false)
       .run(initial)
       .get

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Journal.scala
@@ -332,17 +332,25 @@ object Journal {
     implicit val configReaderConsumerPoolConfig: ConfigReader[ConsumerPoolConfig] = deriveReader
   }
 
-  trait DataIntegrityConfig {
-    def seqNrUniqueness: Boolean
-  }
+  final case class DataIntegrityConfig(
+    /**
+      * If true then duplicated [[SeqNr]] in events will cause [[JournalError]] `Data integrity violated`
+      */
+    seqNrUniqueness: Boolean,
+
+    /**
+      * If true then events with [[RecordId]] different from one in metadata will be filtered out
+      */
+    correlateEventsWithMeta: Boolean,
+  )
 
   object DataIntegrityConfig {
 
-    private case class Implementation(seqNrUniqueness: Boolean) extends DataIntegrityConfig
+    val Default: DataIntegrityConfig = DataIntegrityConfig(
+      seqNrUniqueness         = true,
+      correlateEventsWithMeta = false,
+    )
 
-    val Default: DataIntegrityConfig = Implementation(seqNrUniqueness = true)
-
-    implicit val configReaderDataIntegrityConfig: ConfigReader[DataIntegrityConfig] =
-      deriveReader[Implementation].map(a => a: DataIntegrityConfig)
+    implicit val configReaderDataIntegrityConfig: ConfigReader[DataIntegrityConfig] = deriveReader
   }
 }

--- a/persistence/src/test/resources/akka/persistence/kafka/journal/kafka-journal.conf
+++ b/persistence/src/test/resources/akka/persistence/kafka/journal/kafka-journal.conf
@@ -19,4 +19,5 @@ consumer-pool {
 }
 data-integrity {
   seq-nr-uniqueness =  true
+  correlate-events-with-meta = true
 }

--- a/persistence/src/test/scala/akka/persistence/kafka/journal/KafkaJournalConfigSpec.scala
+++ b/persistence/src/test/scala/akka/persistence/kafka/journal/KafkaJournalConfigSpec.scala
@@ -1,7 +1,7 @@
 package akka.persistence.kafka.journal
 
 import cats.syntax.all.*
-import com.evolutiongaming.kafka.journal.Journal.{CallTimeThresholds, ConsumerPoolConfig}
+import com.evolutiongaming.kafka.journal.Journal.{CallTimeThresholds, ConsumerPoolConfig, DataIntegrityConfig}
 import com.evolutiongaming.kafka.journal.{JournalConfig, KafkaConfig}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
@@ -30,6 +30,7 @@ class KafkaJournalConfigSpec extends AnyFunSuite with Matchers {
       journal            = JournalConfig(headCache = JournalConfig.HeadCache(enabled = false), kafka = KafkaConfig("client-id")),
       jsonCodec          = KafkaJournalConfig.JsonCodec.Jsoniter,
       consumerPool       = ConsumerPoolConfig(multiplier = 1, idleTimeout = 1.second),
+      dataIntegrity      = DataIntegrityConfig(seqNrUniqueness = true, correlateEventsWithMeta = true),
     )
     ConfigSource
       .fromConfig(config)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.5.2-SNAPSHOT"
+ThisBuild / version := "3.6.0"


### PR DESCRIPTION
### Problem
KJ can be in inconsistent state when (after purging) meta from `metajournal` was deleted while events from `journal` left behind. By itself its not an issue, but after the journal used again and new meta inserted - then old events will be available (probably with duplicated `seqNr`).

### Solution 
Create correlation between meta and events that belong to it, i. e. were created while the meta was present. Then, on reading journal, only events that correlate with meta must be used.

### Implementation 
Add `meta_record_id` column to `journal` and `record_id` column to `metajournal` tables. In appending events `RecordId` from meta will be used (if meta has it) and if meta is not present yet - new `RecordId` generated. On reading compare `RecordId` from meta and event ignoring events with another value. `RecordId` is optional value thus validation takes place only if its present in meta.