### PR TITLE
optimization of `append + delete` actions leads to inconsistent state in metajournal table

### DIFF
--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
@@ -1498,6 +1498,9 @@ class ReplicatedCassandraTest extends AnyFunSuite with Matchers {
       actual shouldEqual (expected, true).pure[Try]
     }
 
+    test(s"optimization: delete action sets head's expiration, $suffix") {
+      assert(false, "TODO MR implement!")
+    }
     test(s"optimization: `delete` action advances head's seq_nr, $suffix") {
       val id      = "id"
       val key     = Key(id = id, topic = topic0)

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
@@ -1498,9 +1498,6 @@ class ReplicatedCassandraTest extends AnyFunSuite with Matchers {
       actual shouldEqual (expected, true).pure[Try]
     }
 
-    test(s"optimization: delete action sets head's expiration, $suffix") {
-      assert(false, "TODO MR implement!")
-    }
     test(s"optimization: `delete` action advances head's seq_nr, $suffix") {
       val id      = "id"
       val key     = Key(id = id, topic = topic0)

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/Batch.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/Batch.scala
@@ -102,19 +102,11 @@ private[journal] object Batch {
 
               case (b: Delete, a: Action.Delete) =>
                 if (a.to > b.to) {
-                  if (tail.collectFirst { case b: Appends => cut(b, a) } getOrElse false) {
-                    val delete = deleteOf(a.to, origin orElse a.origin, version orElse a.version)
-                    delete :: Nil
-                  } else {
-                    val delete = deleteOf(a.to, b.origin orElse a.origin, b.version orElse a.version)
-                    delete :: tail
-                  }
-
-                  val cleanTail: List[Batch] = tail.map {
+                  val cleanTail: List[Batch] = tail.mapFilter {
                     case appends: Appends => dropDeleted(appends, a)
                     case delete: Delete   => delete.some
                     case purge: Purge     => purge.some
-                  }.flattenOption
+                  }
 
                   val delete = deleteOf(a.to, b.origin orElse a.origin, b.version orElse a.version)
                   delete :: cleanTail

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
@@ -60,7 +60,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
       ),
       (
         Nel.of(append(offset = 1, seqNr = 1), delete(offset = 2, seqNr = 1), append(offset = 3, seqNr = 2)),
-        List(deletes(offset = 2, seqNr = 1), appends(3, append(offset = 3, seqNr = 2))),
+        List(appends(1, append(offset = 1, seqNr = 1)), deletes(offset = 2, seqNr = 1), appends(3, append(offset = 3, seqNr = 2))),
       ),
       (
         Nel.of(
@@ -69,7 +69,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           append(offset = 3, seqNr = 2),
           delete(offset = 4, seqNr = 2, origin = "origin2"),
         ),
-        List(deletes(offset = 4, seqNr = 2, origin = "origin1")),
+        List(appends(3, append(offset = 3, seqNr = 2)), deletes(offset = 4, seqNr = 2, origin = "origin1")),
       ),
       (
         Nel.of(
@@ -78,7 +78,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           append(offset = 3, seqNr = 2),
           delete(offset = 4, seqNr = 2),
         ),
-        List(deletes(offset = 4, seqNr = 2, origin = "origin")),
+        List(appends(3, append(offset = 3, seqNr = 2)), deletes(offset = 4, seqNr = 2, origin = "origin")),
       ),
       (
         Nel.of(
@@ -87,7 +87,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 3, seqNr = 1, origin = "origin1"),
           delete(offset = 4, seqNr = 2, origin = "origin2"),
         ),
-        List(deletes(offset = 4, seqNr = 2, origin = "origin1")),
+        List(appends(2, append(offset = 2, seqNr = 2)), deletes(offset = 4, seqNr = 2, origin = "origin1")),
       ),
       (
         Nel.of(
@@ -96,7 +96,10 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 3, seqNr = 1),
           delete(offset = 4, seqNr = 2, origin = "origin"),
         ),
-        List(deletes(offset = 4, seqNr = 2, origin = "origin")),
+        List(
+          appends(offset = 2, append(offset = 2, seqNr = 2)),
+          deletes(offset = 4, seqNr = 2, origin = "origin"),
+        ),
       ),
       (Nel.of(delete(offset = 2, seqNr = 1), delete(offset = 3, seqNr = 2)), List(deletes(offset = 3, seqNr = 2))),
       (
@@ -121,7 +124,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 3, seqNr = 2),
           append(offset = 4, seqNr = 3),
         ),
-        List(deletes(offset = 3, seqNr = 2), appends(4, append(offset = 4, seqNr = 3))),
+        List(appends(2, append(offset = 2, seqNr = 2)), deletes(offset = 3, seqNr = 2), appends(4, append(offset = 4, seqNr = 3))),
       ),
       (
         Nel.of(
@@ -132,7 +135,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 4, seqNr = 3),
           append(offset = 5, seqNr = 4),
         ),
-        List(deletes(offset = 4, seqNr = 3), appends(5, append(offset = 5, seqNr = 4))),
+        List(appends(3, append(offset = 3, seqNr = 3)),deletes(offset = 4, seqNr = 3), appends(5, append(offset = 5, seqNr = 4))),
       ),
       (
         Nel.of(
@@ -208,7 +211,6 @@ class BatchSpec extends AnyFunSuite with Matchers {
       ),
       (Nel.of(delete(offset = 0, seqNr = 1), purge(offset = 1)), List(purges(offset = 1))),
       (
-        // TODO MR can we optimize by dropping `delete` after `purge`?
         Nel.of(purge(offset = 0), delete(offset = 1, seqNr = 1)),
         List(purges(offset = 0), deletes(offset = 1, seqNr = 1)),
       ),
@@ -224,16 +226,8 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 3, seqNr = 3),
           delete(offset = 4, seqNr = 5),
         ),
-        // TODO MR possible optimization for above:
-        //  * discard first 2 "appends"
-        //  * from third "append" filter out event with `seqNr: 5`
         List(
-          appends(
-            2,
-            append(offset = 0, seqNr = 1, seqNrs = 2),
-            append(offset = 1, seqNr = 3, seqNrs = 4),
-            append(offset = 2, seqNr = 5, seqNrs = 6),
-          ),
+          appends(offset = 2, append(offset = 2, seqNr = 5, seqNrs = 6)),
           deletes(offset = 4, seqNr = 5),
         ),
       ),
@@ -244,6 +238,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 2, seqNr = 6),
         ),
         List(
+          appends(offset = 0, append(offset = 0, seqNr = 1, seqNrs = 2, 3, 4, 5, 6)),
           deletes(offset = 2, seqNr = 6),
         ),
       ),
@@ -264,8 +259,8 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 1801642, seqNr = 575),
         ),
         List(
-          // TODO MR
-//          deletes(offset = 1801642, deleteToSeqNr = 575, setSeqNr = 575.some),
+          appends(offset = 1801632, append(offset = 1801629, seqNr = 575)),
+          deletes(offset = 1801642, seqNr = 575),
         ),
       ),
     )

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
@@ -256,6 +256,18 @@ class BatchSpec extends AnyFunSuite with Matchers {
           deletes(offset = 2, seqNr = 10),
         ),
       ),
+      (
+        Nel.of( // state: delete_to = 384, seqNr = 573 (in Cassandra)
+          append(offset = 1797039, seqNr = 574),
+          append(offset = 1801629, seqNr = 575),
+          mark(offset   = 1801632),
+          delete(offset = 1801642, seqNr = 575),
+        ),
+        List(
+          // TODO MR
+//          deletes(offset = 1801642, deleteToSeqNr = 575, setSeqNr = 575.some),
+        ),
+      ),
     )
   } {
 

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/BatchSpec.scala
@@ -135,7 +135,7 @@ class BatchSpec extends AnyFunSuite with Matchers {
           delete(offset = 4, seqNr = 3),
           append(offset = 5, seqNr = 4),
         ),
-        List(appends(3, append(offset = 3, seqNr = 3)),deletes(offset = 4, seqNr = 3), appends(5, append(offset = 5, seqNr = 4))),
+        List(appends(3, append(offset = 3, seqNr = 3)), deletes(offset = 4, seqNr = 3), appends(5, append(offset = 5, seqNr = 4))),
       ),
       (
         Nel.of(


### PR DESCRIPTION
We optimize actions to reduce load on Cassandra when in single poll we get actions like:
* append @ 5
* append @ 6
* delete till 6

Optimization removed previous append actions, when `delete` would remove them after insertion.

The optimization keeps the `journal` table in shape, but it fails to update `metajournal` table, like when:
* `metajournal` table has entry with `deleteTo: 4; seqNr: 4`
* after receiving above-mentioned batch, we update `deleteTo` to `4` and `seqNr` stays as it was
* result is that we have `deleteTo: 4; seqNr: 4` (as `DeleteTo` got clamped down to existing `seqNr` to not overshoot future events in journal) - we lost updates: `seqNr: 6` and didn't update `deleteTo: 6`

This happens rarely, usually when client is quiet for some time and then issues "closing" statements. 

As this optimization drops `append @ 6`, it misses update of `expire_after` column in Cassandra.
