### PR TITLE
expose observed journal expirations as metrics

### DIFF
--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicateRecords.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicateRecords.scala
@@ -72,11 +72,13 @@ private[journal] object ReplicateRecords {
           def measure(events: Nel[EventRecord[EventualPayloadAndType]], expireAfter: Option[ExpireAfter]) = {
             for {
               measurements <- measurements(records.size)
-              version       = events.last.version.map(_.value).getOrElse("none")
+              version       = events.head.version.map(_.value).getOrElse("none")
+              expiration    = events.head.metadata.payload.expireAfter.map(_.value.toString).getOrElse("none")
               result <- metrics.append(
                 events        = events.length,
                 bytes         = bytes,
                 clientVersion = version,
+                expiration    = expiration,
                 measurements  = measurements,
               )
               _ <- log.info(msg(events, measurements.replicationLatency, expireAfter))

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicateRecords.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicateRecords.scala
@@ -72,8 +72,8 @@ private[journal] object ReplicateRecords {
           def measure(events: Nel[EventRecord[EventualPayloadAndType]], expireAfter: Option[ExpireAfter]) = {
             for {
               measurements <- measurements(records.size)
-              version       = events.head.version.map(_.value).getOrElse("none")
-              expiration    = events.head.metadata.payload.expireAfter.map(_.value.toString).getOrElse("none")
+              version       = events.last.version.map(_.value).getOrElse("none")
+              expiration    = expireAfter.map(_.value.toString).getOrElse("none")
               result <- metrics.append(
                 events        = events.length,
                 bytes         = bytes,

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/TopicReplicatorSpec.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/TopicReplicatorSpec.scala
@@ -956,7 +956,7 @@ object TopicReplicatorSpec {
 
   implicit val metrics: TopicReplicatorMetrics[StateT] = new TopicReplicatorMetrics[StateT] {
 
-    def append(events: Int, bytes: Long, clientVersion: String, measurements: Measurements) = {
+    def append(events: Int, bytes: Long, clientVersion: String, expiration: String, measurements: Measurements) = {
       StateT { s =>
         s + Metrics.Append(latency = measurements.replicationLatency, events = events, records = measurements.records)
       }


### PR DESCRIPTION
Currently there is no easy way to observer what expirations are used by different clients - only options are:
* peek at Kafka messages
* crawl the `journal` table
* search in source

With this change, `replicator` will expose new metric `*_kafka_journal_client_journal_expiration_info` which will expose [a sample] of expirations as observed in replicated data.