### PR TITLE
Revert some visibility changes

### DIFF
--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadInfo.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadInfo.scala
@@ -25,9 +25,9 @@ import com.evolutiongaming.skafka.Offset
   * @see
   *   [[Journals]] for more details on how it is used.
   */
-private[journal] sealed abstract class HeadInfo extends Product
+sealed abstract class HeadInfo extends Product
 
-private[journal] object HeadInfo {
+object HeadInfo {
 
   /** There are no non-replicated events in Kafka for specific journal.
     *

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/PersistentBinary.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/PersistentBinary.scala
@@ -5,9 +5,9 @@ import com.evolutiongaming.kafka.journal.{FromAttempt, FromBytes, ToBytes}
 import com.evolutiongaming.serialization.SerializedMsg
 import scodec.{Codec, HListCodecEnrichedWithHListSupport, TransformSyntax, ValueCodecEnrichedWithHListSupport, codecs}
 
-private[journal] final case class PersistentBinary(manifest: Option[String], writerUuid: String, payload: SerializedMsg)
+final case class PersistentBinary(manifest: Option[String], writerUuid: String, payload: SerializedMsg)
 
-private[journal] object PersistentBinary {
+object PersistentBinary {
 
   implicit val codecPersistentBinary: Codec[PersistentBinary] = {
     val codec = codecs.optional(codecs.bool, codecs.utf8_32) :: codecs.utf8_32 :: SerializedMsg.CodecSerializedMsg


### PR DESCRIPTION
- PersistentBinary should be public because PersistentJson is
- HeadInfo should be public because HeadCache interface is public, and it can't be implemented because HeadInfo is currently private