### PR TITLE
Use CooperativeStickyAssignor in replicator Kafka consumers

### DIFF
--- a/replicator/src/main/resources/reference.conf
+++ b/replicator/src/main/resources/reference.conf
@@ -19,6 +19,8 @@ evolutiongaming.kafka-journal.replicator {
       max-poll-records = 1000
       auto-offset-reset = "earliest"
       auto-commit = false
+      # using CooperativeStickyAssignor to reduce peak tail replication latency during replicator redeployments
+      partition-assignment-strategy = "org.apache.kafka.clients.consumer.CooperativeStickyAssignor"
     }
   }
 

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorConfig.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorConfig.scala
@@ -16,7 +16,7 @@ final case class ReplicatorConfig(
   topicPrefixes: Nel[String]             = Nel.of("journal"),
   topicDiscoveryInterval: FiniteDuration = 3.seconds,
   cacheExpireAfter: FiniteDuration       = 1.minute,
-  kafka: KafkaConfig                     = KafkaConfig("replicator"),
+  kafka: KafkaConfig                     = ReplicatorConfig.defaultKafkaConfig,
   cassandra: EventualCassandraConfig = EventualCassandraConfig(
     client = CassandraConfig(
       name  = "replicator",
@@ -27,6 +27,16 @@ final case class ReplicatorConfig(
 )
 
 object ReplicatorConfig {
+
+  private val defaultKafkaConfig: KafkaConfig = {
+    val config         = KafkaConfig("replicator")
+    val consumerConfig = config.consumer
+    config.copy(
+      consumer = consumerConfig.copy(
+        partitionAssignmentStrategy = "org.apache.kafka.clients.consumer.CooperativeStickyAssignor",
+      ),
+    )
+  }
 
   val default: ReplicatorConfig = ReplicatorConfig()
 


### PR DESCRIPTION
Use CooperativeStickyAssignor in replicator Kafka consumers

to potentially reduce peak tail replication latency during replicator redeployments