### PR TITLE
New improved Kafka offset commit logic for replicator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,18 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[IncompatibleMethTypeProblem](
     "com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandra#Statements.of",
   ),
+  // TODO: [4.2.0 release] remove
+  // package-private method change
+  ProblemFilters.exclude[IncompatibleMethTypeProblem](
+    "com.evolutiongaming.kafka.journal.replicator.TopicReplicator#ConsumerOf.make",
+  ),
+  // TODO: [4.2.0 release] remove
+  // added method to a public trait without default implementation:
+  // - there could be no sane default implementation but ???, so it will lead to runtime errors either way
+  // - implementing this interface anew is not supposed to be done by the library users in production code.
+  //   test code implementations shouldn't be affected by the bincompat issues and actually benefit from compilation
+  //   error on missing method
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolutiongaming.kafka.journal.KafkaConsumer.commitLater"),
 )
 
 val alias: Seq[sbt.Def.Setting[?]] =

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/KafkaConsumer.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/KafkaConsumer.scala
@@ -23,6 +23,8 @@ trait KafkaConsumer[F[_], K, V] {
 
   def commit(offsets: Nem[TopicPartition, OffsetAndMetadata]): F[Unit]
 
+  def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]): F[Unit]
+
   def topics: F[Set[Topic]]
 
   def partitions(topic: Topic): F[Set[Partition]]
@@ -82,6 +84,10 @@ object KafkaConsumer {
         consumer.commit(offsets)
       }
 
+      def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]) = {
+        consumer.commitLater(offsets)
+      }
+
       def topics: F[Set[Topic]] = {
         consumer
           .topics
@@ -125,6 +131,8 @@ object KafkaConsumer {
 
       def commit(offsets: Nem[TopicPartition, OffsetAndMetadata]) = fg(self.commit(offsets))
 
+      def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]) = fg(self.commitLater(offsets))
+
       def topics = fg(self.topics)
 
       def partitions(topic: Topic) = fg(self.partitions(topic))
@@ -145,6 +153,8 @@ object KafkaConsumer {
       def poll(timeout: FiniteDuration) = f(self.poll(timeout), "poll")
 
       def commit(offsets: Nem[TopicPartition, OffsetAndMetadata]) = f(self.commit(offsets), "commit")
+
+      def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]) = f(self.commitLater(offsets), "commit_later")
 
       def topics = f(self.topics, "topics")
 
@@ -173,6 +183,8 @@ object KafkaConsumer {
         }
 
         def commit(offsets: Nem[TopicPartition, OffsetAndMetadata]) = self.commit(offsets)
+
+        def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]) = self.commitLater(offsets)
 
         def topics = self.topics
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val random               = "com.evolutiongaming"    %% "random"                % "1.0.0"
   val retry                = "com.evolutiongaming"    %% "retry"                 % "3.0.1"
   val sstream              = "com.evolutiongaming"    %% "sstream"               % "1.0.1"
-  val skafka               = "com.evolutiongaming"    %% "skafka"                % "17.1.3"
+  val skafka               = "com.evolutiongaming"    %% "skafka"                % "17.1.4"
   val `akka-test-actor`    = "com.evolutiongaming"    %% "akka-test-actor"       % "0.1.0"
   val scache               = "com.evolution"          %% "scache"                % "5.1.3"
   val `resource-pool`      = "com.evolution"          %% "resource-pool"         % "1.0.5"

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/TopicCommit.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/TopicCommit.scala
@@ -1,44 +1,133 @@
 package com.evolutiongaming.kafka.journal.replicator
 
 import cats.Applicative
-import cats.data.NonEmptyMap as Nem
-import cats.effect.kernel.Concurrent
-import cats.effect.{Clock, Ref}
+import cats.data.{NonEmptyMap as Nem, NonEmptySet}
+import cats.effect.*
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.catshelper.DataHelper.*
+import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.journal.KafkaConsumer
+import com.evolutiongaming.kafka.journal.replicator.commit.AsyncPeriodicTopicCommit
 import com.evolutiongaming.kafka.journal.util.TemporalHelper.*
 import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.RebalanceCallback
 
 import java.time.Instant
+import scala.annotation.nowarn
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration.*
 
-trait TopicCommit[F[_]] {
+/**
+ * Kafka partition offset commit logic for replicator internal topic processing API
+ * ([[TopicConsumer]], [[ConsumeTopic]]).
+ *
+ * @tparam F effect type
+ */
+private[journal] trait TopicCommit[F[_]] {
+// journal-private because the places where it is used are journal-private - TopicConsumer, ConsumeTopic
 
+  /**
+   * Mark offsets for commit.
+   * 
+   * The method should be called after each processing step, i.e., after each consumer poll result processing.
+   * 
+   * Please note that offsets passed here should follow the same logic as for Java consumer commit methods:
+   * if offset N is known to be processed, offset N+1 should be committed - offset from which you want to start your
+   * processing next time.
+   * 
+   * Depending on the underlying implementation, this method might execute commit synchronously with the call or
+   * schedule it for later.
+   * 
+   * @param offsets partition offsets to commit
+   */
   def apply(offsets: Nem[Partition, Offset]): F[Unit]
+
+  /**
+   * Notify topic commit logic about new partitions assigned during rebalance - called in
+   * [[com.evolutiongaming.skafka.consumer.RebalanceListener1.onPartitionsAssigned]].
+   * 
+   * @param partitions assigned partitions
+   *                   
+   * @return [[RebalanceCallback]]
+   */
+  def onPartitionsAssigned(@nowarn("cat=unused") partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] =
+    RebalanceCallback.empty
+
+  /**
+   * Notify topic commit logic about partitions revoked during rebalance - called in
+   * [[com.evolutiongaming.skafka.consumer.RebalanceListener1.onPartitionsRevoked]].
+   * 
+   * Could be used to commit offsets for revoked partitions using
+   * [[RebalanceCallback.commit]] in order not to lose progress during rebalance.
+   *
+   * @param partitions revoked partitions
+   *
+   * @return [[RebalanceCallback]]
+   */
+  def onPartitionsRevoked(@nowarn("cat=unused") partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] =
+    RebalanceCallback.empty
+
+  /**
+   * Notify topic commit logic about partitions lost - called in
+   * [[com.evolutiongaming.skafka.consumer.RebalanceListener1.onPartitionsLost]].
+   *
+   * When partitions are lost as opposed to being revoked:
+   * [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost(java.util.Collection)]]
+   * 
+   * Usually nothing could be done in this case apart from removing the lost partitions from internal state, if there
+   * is any.
+   * As another consumer might already handle the lost partitions by this point, it is highly recommended not to
+   * try to commit offsets for those.
+   *
+   * @param partitions lost partitions
+   *
+   * @return [[RebalanceCallback]]
+   */
+  def onPartitionsLost(@nowarn("cat=unused") partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] =
+    RebalanceCallback.empty
 }
 
-object TopicCommit {
+private[journal] object TopicCommit {
 
-  def empty[F[_]: Applicative]: TopicCommit[F] = (_: Nem[Partition, Offset]) => ().pure[F]
+  def empty[F[_]: Applicative]: TopicCommit[F] = new EmptyTopicCommit[F]
 
+  @deprecated("renamed to `sync`, use it instead", since = "4.2.0")
   def apply[F[_]](
     topic: Topic,
     metadata: String,
-    consumer: KafkaConsumer[F, _, _],
-  ): TopicCommit[F] = { (offsets: Nem[Partition, Offset]) =>
-    {
-      val offsets1 = offsets.mapKV { (partition, offset) =>
-        val offset1    = OffsetAndMetadata(offset, metadata)
-        val partition1 = TopicPartition(topic, partition)
-        (partition1, offset1)
-      }
-      consumer.commit(offsets1)
-    }
+    consumer: KafkaConsumer[F, ?, ?],
+  ): TopicCommit[F] = {
+    sync[F](
+      topic          = topic,
+      commitMetadata = metadata,
+      consumer       = consumer,
+    )
   }
 
+  /**
+   * [[TopicCommit]] which performs synchronous blocking commit on each offset mark call.
+   * 
+   * @param topic processed topic name
+   * @param commitMetadata metadata to pass to each consumer commit call
+   * @param consumer [[KafkaConsumer]] to call commit on
+   * @tparam F effect type
+   */
+  def sync[F[_]](
+    topic: Topic,
+    commitMetadata: String,
+    consumer: KafkaConsumer[F, ?, ?],
+  ): TopicCommit[F] = new SyncTopicCommit[F](
+    topic          = topic,
+    commitMetadata = commitMetadata,
+    consumer       = consumer,
+  )
+
+  @deprecated(
+    "use `asyncPeriodic` instead - the delayed impl blocks the poll-loop on commit and " +
+      "looses progress on rebalance and shutdown",
+    since = "4.2.0",
+  )
   def delayed[F[_]: Concurrent: Clock](
     delay: FiniteDuration,
     commit: TopicCommit[F],
@@ -51,9 +140,9 @@ object TopicCommit {
       stateRef  <- Ref[F].of(State(timestamp + delay))
     } yield {
       new TopicCommit[F] {
-        def apply(offsets: Nem[Partition, Offset]) = {
+        def apply(offsets: Nem[Partition, Offset]): F[Unit] = {
 
-          def apply(state: State, timestamp: Instant) = {
+          def apply(state: State, timestamp: Instant): F[State] = {
             val offsets1 = state.offsets ++ offsets.toSortedMap
             if (state.until <= timestamp) {
               offsets1
@@ -75,6 +164,61 @@ object TopicCommit {
           } yield {}
         }
       }
+    }
+  }
+
+  /**
+   * [[TopicCommit]] which commits progress periodically using an async commit method, without blocking the main
+   * poll loop.
+   *
+   * Properly handles rebalance events - when partitions are revoked, it performs a synchronous commit for revoked
+   * partitions in order not to lose the progress.
+   * Since the partition revoke callback is also called on consumer shutdown, the same logic saves the progress on
+   * app shutdown.
+   *
+   * @param topic processed topic name
+   * @param commitMetadata metadata to pass to each consumer commit call
+   * @param commitPeriod delay between periodic async commit calls
+   * @param consumer [[KafkaConsumer]] to call commit on
+   * @param log logger instance.
+   *            The logic here doesn't add anything to log statements which can identify the topic or particular
+   *            consumer instance.
+   *            If you have more than one topic-processor in the app, add that information to the logger before passing
+   *            it here.
+   * @tparam F effect type
+   * @return implementation wrapped in Resource - don't forget to release it after use!
+   */
+  def asyncPeriodic[F[_]: Temporal](
+    topic: Topic,
+    commitMetadata: String,
+    commitPeriod: FiniteDuration,
+    consumer: KafkaConsumer[F, ?, ?],
+    log: Log[F],
+  ): Resource[F, TopicCommit[F]] =
+    AsyncPeriodicTopicCommit.make(
+      topic          = topic,
+      commitMetadata = commitMetadata,
+      commitPeriod   = commitPeriod,
+      consumer       = consumer,
+      log            = log,
+    )
+
+  private final class EmptyTopicCommit[F[_]: Applicative] extends TopicCommit[F] {
+    override def apply(offsets: Nem[Partition, Offset]): F[Unit] = ().pure
+  }
+
+  private final class SyncTopicCommit[F[_]](
+    topic: Topic,
+    commitMetadata: String,
+    consumer: KafkaConsumer[F, ?, ?],
+  ) extends TopicCommit[F] {
+    override def apply(offsets: Nem[Partition, Offset]): F[Unit] = {
+      val offsets1 = offsets.mapKV { (partition, offset) =>
+        val offset1    = OffsetAndMetadata(offset, commitMetadata)
+        val partition1 = TopicPartition(topic, partition)
+        (partition1, offset1)
+      }
+      consumer.commit(offsets1)
     }
   }
 }

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommit.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommit.scala
@@ -1,0 +1,206 @@
+package com.evolutiongaming.kafka.journal.replicator.commit
+
+import cats.Applicative
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.*
+import cats.effect.syntax.all.*
+import cats.syntax.all.*
+import com.evolutiongaming.catshelper.DataHelper.*
+import com.evolutiongaming.catshelper.{Log, MonadThrowable}
+import com.evolutiongaming.kafka.journal.KafkaConsumer
+import com.evolutiongaming.kafka.journal.replicator.TopicCommit
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.RebalanceCallback
+import com.evolutiongaming.skafka.consumer.RebalanceCallback.syntax.*
+import org.apache.kafka.common.errors.RebalanceInProgressException
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * @see [[TopicCommit.asyncPeriodic]]
+ */
+private[replicator] final class AsyncPeriodicTopicCommit[F[_]: MonadThrowable] private[commit] (
+  topic: Topic,
+  commitMetadata: Metadata,
+  consumer: KafkaConsumer[F, ?, ?],
+  stateRef: Ref[F, AsyncPeriodicTopicCommit.State],
+  log: Log[F],
+) extends TopicCommit[F] {
+  override def apply(offsets: NonEmptyMap[Partition, Offset]): F[Unit] = {
+    stateRef.update(_.updateMarkedOffsetsForAllAssigned(offsets.toSortedMap))
+  }
+
+  override def onPartitionsAssigned(partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] = {
+    stateRef.update(_.addAssignedPartitions(partitions.toSortedSet)).lift
+  }
+
+  override def onPartitionsRevoked(partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] = {
+    for {
+      revokedToCommit <- stateRef.modify { state =>
+        val revokedToCommit = state.partitionOffsetsToCommit.view.filterKeys(partitions.contains).toMap
+        state.removeAssignedPartitions(partitions.toSortedSet) -> revokedToCommit
+      }.lift
+
+      anythingCommitted <- commitIfNotEmpty[RebalanceCallback[F, *]](revokedToCommit, commitF = RebalanceCallback.commit)
+        .recoverWith {
+          case t: Throwable =>
+            log.error(s"offset commit for revoked partitions on rebalance failed: ${t.getMessage}", t).lift.as(false)
+        }
+
+      _ <-
+        if (anythingCommitted) log.debug(s"offset commit for revoked partitions on rebalance success: $revokedToCommit").lift
+        else RebalanceCallback.empty
+    } yield ()
+  }
+
+  override def onPartitionsLost(partitions: NonEmptySet[Partition]): RebalanceCallback[F, Unit] = {
+    RebalanceCallback.lift(stateRef.update(_.removeAssignedPartitions(partitions.toSortedSet)))
+  }
+
+  // opened to the package for tests
+  private[commit] def periodicCommitStep(): F[Unit] = {
+    for {
+      state          <- stateRef.get
+      offsetsToCommit = state.partitionOffsetsToCommit
+
+      anythingCommitted <- commitIfNotEmpty[F](offsetsToCommit, commitF = consumer.commitLater)
+        .recoverWith {
+          case _: RebalanceInProgressException =>
+            Applicative[F].pure(false) // ignore, commit will be retried on the next step
+        }
+
+      _ <-
+        if (anythingCommitted) {
+          stateRef.update(_.updateCommittedOffsetsForAllAssigned(offsetsToCommit)) >>
+            log.debug(s"periodic offset commit success: $offsetsToCommit")
+        } else Applicative[F].unit
+    } yield ()
+  }
+
+  private def commitIfNotEmpty[G[_]: MonadThrowable](
+    offsets: Map[Partition, Offset],
+    commitF: NonEmptyMap[TopicPartition, OffsetAndMetadata] => G[Unit],
+  ): G[Boolean] = {
+    offsets.toNem.fold(Applicative[G].pure(false)) { offsetsNem =>
+      commitF(
+        offsetsNem
+          .mapBoth {
+            case (partition, offset) => TopicPartition(topic, partition) -> OffsetAndMetadata(offset, commitMetadata)
+          },
+      ).as(true)
+    }
+  }
+}
+
+private[replicator] object AsyncPeriodicTopicCommit {
+
+  def make[F[_]: Temporal](
+    topic: Topic,
+    commitMetadata: Metadata,
+    commitPeriod: FiniteDuration,
+    consumer: KafkaConsumer[F, ?, ?],
+    log: Log[F],
+  ): Resource[F, TopicCommit[F]] = {
+    val mkInstanceF: F[AsyncPeriodicTopicCommit[F]] = for {
+      stateRef <- Ref.of[F, State](State())
+    } yield new AsyncPeriodicTopicCommit[F](
+      topic          = topic,
+      commitMetadata = commitMetadata,
+      consumer       = consumer,
+      stateRef       = stateRef,
+      log            = log,
+    )
+
+    for {
+      instance <- mkInstanceF.toResource
+
+      periodicCommitProcessF = (
+        Temporal[F].sleep(commitPeriod) >>
+          instance
+            .periodicCommitStep()
+            .recoverWith {
+              case t: Throwable =>
+                log.error(s"periodic offset commit failed: ${t.getMessage}", t)
+            }
+      ).foreverM[Unit]
+
+      _ <- periodicCommitProcessF.background
+    } yield instance
+  }
+
+  // opened to the package for tests
+  private[commit] final case class State(
+    assignedPartitions: Map[Partition, PartitionState] = Map.empty,
+  ) {
+    def addAssignedPartitions(partitions: Iterable[Partition]): State = {
+      copy(
+        assignedPartitions = partitions.foldLeft(assignedPartitions) { (prevAssigned, partition) =>
+          prevAssigned.updatedWith(partition)(prevStateOpt => prevStateOpt.getOrElse(PartitionState()).some)
+        },
+      )
+    }
+
+    def removeAssignedPartitions(partitions: Iterable[Partition]): State = {
+      copy(assignedPartitions = assignedPartitions.removedAll(partitions))
+    }
+
+    def updateCommittedOffsetsForAllAssigned(offsets: Iterable[(Partition, Offset)]): State = {
+      updateForAllAssigned(offsets)(_.updateCommittedIfNeeded(_))
+    }
+
+    def updateMarkedOffsetsForAllAssigned(offsets: Iterable[(Partition, Offset)]): State = {
+      updateForAllAssigned(offsets)(_.updateMarkedIfNeeded(_))
+    }
+
+    def partitionOffsetsToCommit: Map[Partition, Offset] = {
+      assignedPartitions
+        .view
+        .flatMap {
+          case (partition, partitionState) => partitionState.needToCommit.map(partition -> _)
+        }
+        .toMap
+    }
+
+    private def updateForAllAssigned(
+      offsets: Iterable[(Partition, Offset)],
+    )(f: (PartitionState, Offset) => PartitionState): State = {
+      copy(
+        assignedPartitions = offsets.foldLeft(assignedPartitions) {
+          case (prevAssignedPartitions, (partition, offset)) =>
+            prevAssignedPartitions.updatedWith(partition)(partitionStateOpt => partitionStateOpt.map(f(_, offset)))
+        },
+      )
+    }
+  }
+
+  // opened to the package for tests
+  private[commit] final case class PartitionState(
+    markedOffsetOpt: Option[Offset]    = None,
+    committedOffsetOpt: Option[Offset] = None,
+  ) {
+    def needToCommit: Option[Offset] = {
+      markedOffsetOpt.filter { markedOffset =>
+        committedOffsetOpt.fold(true)(committedOffset => markedOffset > committedOffset)
+      }
+    }
+
+    def updateMarkedIfNeeded(newMarkedOffset: Offset): PartitionState = {
+      markedOffsetOpt match {
+        case Some(markedOffset) if markedOffset >= newMarkedOffset =>
+          this
+        case _ =>
+          copy(markedOffsetOpt = Some(newMarkedOffset))
+      }
+    }
+
+    def updateCommittedIfNeeded(newCommittedOffset: Offset): PartitionState = {
+      committedOffsetOpt match {
+        case Some(committedOffset) if committedOffset >= newCommittedOffset =>
+          this
+        case _ =>
+          copy(committedOffsetOpt = Some(newCommittedOffset))
+      }
+    }
+  }
+
+}

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DelayedTopicCommitTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DelayedTopicCommitTest.scala
@@ -8,15 +8,17 @@ import com.evolutiongaming.skafka.{Offset, Partition}
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
-class TopicCommitTest extends AsyncFunSuite with Matchers {
+@nowarn("cat=deprecation")
+class DelayedTopicCommitTest extends AsyncFunSuite with Matchers {
 
   test("delayed") {
 
     def commitOf(deferred: Deferred[IO, Unit], commitsRef: Ref[IO, List[Nem[Partition, Offset]]])(implicit clock: Clock[IO]) = {
       val commit = new TopicCommit[IO] {
-        def apply(offsets: Nem[Partition, Offset]) = {
+        def apply(offsets: Nem[Partition, Offset]): IO[Unit] = {
           commitsRef.update { offsets :: _ } *> deferred.complete(()).void
         }
       }

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJobTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJobTest.scala
@@ -47,8 +47,9 @@ class DistributeJobTest extends AsyncFunSuite with Matchers {
                 .sleep(timeout)
                 .as(ConsumerRecords.empty[K, V])
             }
-            def commit(offsets: Nem[TopicPartition, OffsetAndMetadata]) = ().pure[IO]
-            def topics                                                  = Set.empty[Topic].pure[IO]
+            def commit(offsets: Nem[TopicPartition, OffsetAndMetadata])      = ().pure[IO]
+            def commitLater(offsets: Nem[TopicPartition, OffsetAndMetadata]) = ().pure[IO]
+            def topics                                                       = Set.empty[Topic].pure[IO]
             def partitions(topic: Topic) = {
               Set(partition0, partition1, partition2).pure[IO]
             }

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/EmptyRebalanceConsumer.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/EmptyRebalanceConsumer.scala
@@ -8,7 +8,9 @@ import java.time.Instant
 import scala.concurrent.duration.*
 import scala.util.{Failure, Try}
 
-object EmptyRebalanceConsumer extends RebalanceConsumer {
+object EmptyRebalanceConsumer extends EmptyRebalanceConsumer
+
+trait EmptyRebalanceConsumer extends RebalanceConsumer {
   override def assignment(): Try[Set[TopicPartition]] = Failure(new NotImplementedError)
 
   override def beginningOffsets(partitions: NonEmptySet[TopicPartition]): Try[Map[TopicPartition, Offset]] = Failure(

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/SKafkaTestUtils.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/SKafkaTestUtils.scala
@@ -1,0 +1,11 @@
+package com.evolutiongaming.kafka.journal.replicator
+
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+
+object SKafkaTestUtils {
+  def offset(n: Int): Offset = Offset.unsafe(n)
+
+  def p(n: Int): Partition = Partition.unsafe(n)
+
+  def tp(topic: String, n: Int): TopicPartition = TopicPartition(topic, p(n))
+}

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommitStateTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommitStateTest.scala
@@ -1,0 +1,187 @@
+package com.evolutiongaming.kafka.journal.replicator.commit
+
+import cats.syntax.all.*
+import com.evolutiongaming.kafka.journal.replicator.SKafkaTestUtils.*
+import com.evolutiongaming.kafka.journal.replicator.commit.AsyncPeriodicTopicCommit.*
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class AsyncPeriodicTopicCommitStateTest extends AnyFreeSpec with Matchers {
+
+  "PartitionState" - {
+
+    "has nothing to commit" - {
+      "on start" in {
+        pState().needToCommit shouldEqual none
+      }
+      "if nothing marked" in {
+        pState(committed = 1.some).needToCommit shouldEqual none
+      }
+      "if marked offset is not higher than committed" in {
+        pState(
+          marked    = 1.some,
+          committed = 1.some,
+        ).needToCommit shouldEqual none
+      }
+    }
+
+    "has something to commit" - {
+      "if there is a marked offset but nothing committed yet" in {
+        pState(marked = 1.some).needToCommit shouldEqual offset(1).some
+      }
+      "if marked offset is higher than committed" in {
+        pState(
+          marked    = 2.some,
+          committed = 1.some,
+        ).needToCommit shouldEqual offset(2).some
+      }
+    }
+
+    "when updating marked offset" - {
+      "updates if new value is higher" in {
+        pState(
+          marked    = 2.some,
+          committed = 1.some,
+        ).updateMarkedIfNeeded(offset(3)) shouldEqual
+          pState(
+            marked    = 3.some,
+            committed = 1.some,
+          )
+      }
+
+      "ignore update if the new value is not higher" in {
+        pState(
+          marked    = 2.some,
+          committed = 1.some,
+        ).updateMarkedIfNeeded(offset(1)) shouldEqual
+          pState(
+            marked    = 2.some,
+            committed = 1.some,
+          )
+      }
+    }
+
+    "when updating committed offset" - {
+      "updates if new value is higher" in {
+        pState(
+          marked    = 1.some,
+          committed = 1.some,
+        ).updateCommittedIfNeeded(offset(2)) shouldEqual
+          pState(
+            marked    = 1.some,
+            committed = 2.some,
+          )
+      }
+
+      "ignore update if the new value is not higher" in {
+        pState(
+          marked    = 1.some,
+          committed = 2.some,
+        ).updateCommittedIfNeeded(offset(1)) shouldEqual
+          pState(
+            marked    = 1.some,
+            committed = 2.some,
+          )
+      }
+    }
+  }
+
+  "State" - {
+    "has something to commit when some partitions have uncommitted progress" in {
+      var state = State()
+      state = state.addAssignedPartitions(Vector(p(0), p(1), p(2)))
+      state = state.updateCommittedOffsetsForAllAssigned(
+        Vector(
+          p(0) -> offset(1),
+          p(1) -> offset(11),
+          p(2) -> offset(21),
+        ),
+      )
+      state = state.updateMarkedOffsetsForAllAssigned(
+        Vector(
+          p(0) -> offset(2),
+          p(1) -> offset(11),
+          p(2) -> offset(22),
+        ),
+      )
+
+      state.partitionOffsetsToCommit shouldEqual Map(
+        p(0) -> offset(2),
+        p(2) -> offset(22),
+      )
+    }
+
+    "removes revoked/lost partitions from commit" in {
+      var state = State()
+      state = state.addAssignedPartitions(Vector(p(0), p(1), p(2)))
+      state = state.updateCommittedOffsetsForAllAssigned(
+        Vector(
+          p(0) -> offset(1),
+          p(1) -> offset(11),
+          p(2) -> offset(21),
+        ),
+      )
+      state = state.updateMarkedOffsetsForAllAssigned(
+        Vector(
+          p(0) -> offset(2),
+          p(1) -> offset(12),
+          p(2) -> offset(22),
+        ),
+      )
+      state.partitionOffsetsToCommit shouldEqual Map(
+        p(0) -> offset(2),
+        p(1) -> offset(12),
+        p(2) -> offset(22),
+      )
+
+      state = state.removeAssignedPartitions(Vector(p(0)))
+
+      state.partitionOffsetsToCommit shouldEqual Map(
+        p(1) -> offset(12),
+        p(2) -> offset(22),
+      )
+    }
+
+    "ignores updates on non-assigned partitions" - {
+      "when marked offsets updated" in {
+        val state = State().addAssignedPartitions(Vector(p(0), p(2)))
+
+        state.updateMarkedOffsetsForAllAssigned(
+          Vector(
+            p(0) -> offset(1),
+            p(1) -> offset(2),
+            p(2) -> offset(3),
+          ),
+        ) shouldEqual State(
+          Map(
+            p(0) -> pState(marked = 1.some),
+            p(2) -> pState(marked = 3.some),
+          ),
+        )
+      }
+
+      "when committed offsets updated" in {
+        val state = State().addAssignedPartitions(Vector(p(0), p(2)))
+
+        state.updateCommittedOffsetsForAllAssigned(
+          Vector(
+            p(0) -> offset(1),
+            p(1) -> offset(2),
+            p(2) -> offset(3),
+          ),
+        ) shouldEqual State(
+          Map(
+            p(0) -> pState(committed = 1.some),
+            p(2) -> pState(committed = 3.some),
+          ),
+        )
+      }
+    }
+  }
+
+  private def pState(marked: Option[Int] = None, committed: Option[Int] = None): PartitionState =
+    PartitionState(
+      markedOffsetOpt    = marked.map(offset),
+      committedOffsetOpt = committed.map(offset),
+    )
+}

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommitTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/commit/AsyncPeriodicTopicCommitTest.scala
@@ -1,0 +1,195 @@
+package com.evolutiongaming.kafka.journal.replicator.commit
+
+import cats.data.{NonEmptyMap, NonEmptySet}
+import cats.effect.{Ref, SyncIO}
+import com.evolutiongaming.catshelper.{Log, ToTry}
+import com.evolutiongaming.kafka.journal.KafkaConsumer
+import com.evolutiongaming.kafka.journal.replicator.EmptyRebalanceConsumer
+import com.evolutiongaming.kafka.journal.replicator.SKafkaTestUtils.*
+import com.evolutiongaming.skafka.*
+import com.evolutiongaming.skafka.consumer.{ConsumerRecords, RebalanceCallback, RebalanceConsumer, RebalanceListener1}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+import scala.concurrent.duration.*
+import scala.util.Try
+
+class AsyncPeriodicTopicCommitTest extends AnyFreeSpec with Matchers {
+  import AsyncPeriodicTopicCommitTest.*
+
+  "AsyncPeriodicTopicCommit" - {
+    "should perform periodic async commit for assigned partitions" in {
+      val consumer = new TestConsumer
+      val impl     = makeImpl(consumer)
+      consumer.runCbUnsafe(impl.onPartitionsAssigned(NonEmptySet.of(p(0), p(1))))
+
+      impl(
+        NonEmptyMap.of(
+          p(0) -> offset(1),
+          p(1) -> offset(11),
+          p(2) -> offset(21),
+        ),
+      ).unsafeRunSync()
+      consumer.getRecordedActions shouldEqual Vector()
+
+      impl.periodicCommitStep().unsafeRunSync()
+      consumer.getRecordedActions shouldEqual Vector(
+        Action.AsyncCommit(
+          NonEmptyMap.of(
+            tp(topic, 0) -> OffsetAndMetadata(offset(1), commitMetadata),
+            tp(topic, 1) -> OffsetAndMetadata(offset(11), commitMetadata),
+          ),
+        ),
+      )
+
+      consumer.clearRecordedActions()
+      impl(
+        NonEmptyMap.of(
+          p(0) -> offset(2),
+        ),
+      ).unsafeRunSync()
+      consumer.getRecordedActions shouldEqual Vector()
+
+      impl.periodicCommitStep().unsafeRunSync()
+      consumer.getRecordedActions shouldEqual Vector(
+        Action.AsyncCommit(
+          NonEmptyMap.of(
+            tp(topic, 0) -> OffsetAndMetadata(offset(2), commitMetadata),
+          ),
+        ),
+      )
+    }
+
+    "should perform sync commit for revoked partitions" in {
+      val consumer = new TestConsumer
+      val impl     = makeImpl(consumer)
+      consumer.runCbUnsafe(impl.onPartitionsAssigned(NonEmptySet.of(p(0), p(1), p(2))))
+
+      impl(
+        NonEmptyMap.of(
+          p(0) -> offset(1),
+          p(1) -> offset(11),
+          p(2) -> offset(21),
+        ),
+      ).unsafeRunSync()
+
+      consumer.getRecordedActions shouldEqual Vector()
+
+      consumer.runCbUnsafe(impl.onPartitionsRevoked(NonEmptySet.of(p(0), p(2))))
+
+      consumer.getRecordedActions shouldEqual Vector(
+        Action.SyncCommit(
+          NonEmptyMap.of(
+            tp(topic, 0) -> OffsetAndMetadata(offset(1), commitMetadata),
+            tp(topic, 2) -> OffsetAndMetadata(offset(21), commitMetadata),
+          ),
+        ),
+      )
+    }
+
+    "should ignore lost partitions" in {
+      val consumer = new TestConsumer
+      val impl     = makeImpl(consumer)
+      consumer.runCbUnsafe(impl.onPartitionsAssigned(NonEmptySet.of(p(0), p(1), p(2))))
+
+      impl(
+        NonEmptyMap.of(
+          p(0) -> offset(1),
+          p(1) -> offset(11),
+          p(2) -> offset(21),
+        ),
+      ).unsafeRunSync()
+
+      consumer.getRecordedActions shouldEqual Vector()
+
+      consumer.runCbUnsafe(impl.onPartitionsLost(NonEmptySet.of(p(0), p(2))))
+
+      consumer.getRecordedActions shouldEqual Vector()
+
+      impl.periodicCommitStep().unsafeRunSync()
+
+      consumer.getRecordedActions shouldEqual Vector(
+        Action.AsyncCommit(
+          NonEmptyMap.of(
+            tp(topic, 1) -> OffsetAndMetadata(offset(11), commitMetadata),
+          ),
+        ),
+      )
+    }
+  }
+
+  private def makeImpl(consumer: TestConsumer): AsyncPeriodicTopicCommit[SyncIO] = {
+    new AsyncPeriodicTopicCommit[SyncIO](
+      topic          = topic,
+      commitMetadata = commitMetadata,
+      consumer       = consumer,
+      log            = Log.empty,
+      stateRef       = Ref.unsafe[SyncIO, AsyncPeriodicTopicCommit.State](AsyncPeriodicTopicCommit.State()),
+    )
+  }
+}
+
+private object AsyncPeriodicTopicCommitTest {
+  val topic          = "my-topic"
+  val commitMetadata = "my-commit-meta"
+
+  val doNotCallF: SyncIO[Nothing] = SyncIO.raiseError(new RuntimeException("method not supposed to be called"))
+
+  implicit val syncIoToTry: ToTry[SyncIO] = new ToTry[SyncIO] {
+    override def apply[A](fa: SyncIO[A]): Try[A] = Try(fa.unsafeRunSync())
+  }
+
+  sealed trait Action
+  object Action {
+    final case class SyncCommit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) extends Action
+    final case class AsyncCommit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]) extends Action
+  }
+
+  private class TestConsumer extends KafkaConsumer[SyncIO, String, String] {
+
+    private val recordedActions: mutable.ArrayBuffer[Action] = mutable.ArrayBuffer.empty[Action]
+
+    private val rebalanceConsumer: RebalanceConsumer = new EmptyRebalanceConsumer {
+      override def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): Try[Unit] = {
+        Try {
+          recordedActions += Action.SyncCommit(offsets)
+        }
+      }
+    }
+
+    def getRecordedActions: Vector[Action] = recordedActions.toVector
+
+    def clearRecordedActions(): Unit = recordedActions.clear()
+
+    def runCbUnsafe(rebalanceCallback: RebalanceCallback[SyncIO, Unit]): Unit = {
+      rebalanceCallback.run(rebalanceConsumer).get
+    }
+
+    override def commitLater(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): SyncIO[Unit] = {
+      SyncIO.delay {
+        recordedActions += Action.AsyncCommit(offsets)
+      }
+    }
+
+    override def commit(offsets: NonEmptyMap[TopicPartition, OffsetAndMetadata]): SyncIO[Unit] = {
+      SyncIO.delay {
+        recordedActions += Action.SyncCommit(offsets)
+      }
+    }
+
+    override def assign(partitions: NonEmptySet[TopicPartition]): SyncIO[Unit] = doNotCallF
+
+    override def seek(partition: TopicPartition, offset: Offset): SyncIO[Unit] = doNotCallF
+
+    override def subscribe(topic: Topic, listener: RebalanceListener1[SyncIO]): SyncIO[Unit] = doNotCallF
+
+    override def poll(timeout: FiniteDuration): SyncIO[ConsumerRecords[String, String]] = doNotCallF
+
+    override def topics: SyncIO[Set[Topic]] = doNotCallF
+
+    override def partitions(topic: Topic): SyncIO[Set[Partition]] = doNotCallF
+
+    override def assignment: SyncIO[Set[TopicPartition]] = doNotCallF
+  }
+}


### PR DESCRIPTION
The next release version should have a minor increment - 4.2.0

- TopicCommit.apply renamed to TopicCommit.sync, TopicCommit.apply deprecated
- Added TopicCommit.asyncPeriodic implementation
- TopicCommit.delayed deprecated in favor of TopicCommit.asyncPeriodic
- TopicCommit.asyncPeriodic is used by default in the replicator
- updated skafka for an async commit method fix

Main features of asyncPeriodic:
- periodic commits are done asynchronously without blocking the main poll loop, improving latency
- it properly handles rebalance, not loosing progress for revoked partitions
- same logic commits offsets on app shutdown because Java consumer invokes revoke partition callbacks on closure
- gracefully handles RebalanceInProgressException

Additionally:
- made TopicCommit journal package private - it is used only in journal package private APIs, and it is not supposed to be used outside the internal journal code
- ToTry[StateT] impl in ConsumeTopicTest - it didn't work on flatMap'ed RebalanceCallback's