### PR TITLE
Replace kafka-launcher with testcontainers-kafka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val journal = project
       Akka.stream,
       Akka.testkit % Test,
       Akka.slf4j   % Test,
-      Kafka.`kafka-clients`,
+      `kafka-clients`,
       skafka,
       scalatest        % Test,
       `executor-tools` % Test,
@@ -177,22 +177,20 @@ lazy val `tests` = project
       Test / fork := true,
       Test / parallelExecution := false,
       Test / javaOptions ++= Seq("-Xms3G", "-Xmx3G"),
-      Test / envVars ++= Map("TESTCONTAINERS_RYUK_DISABLED" -> "true"),
     ),
   )
   .dependsOn(persistence % "test->test;compile->compile", `persistence-circe`, replicator)
   .settings(
     libraryDependencies ++= Seq(
       `cats-helper`,
-      Kafka.kafka                % Test,
-      `kafka-launcher`           % Test,
-      `testcontainers-cassandra` % Test,
-      scalatest                  % Test,
-      Akka.`persistence-tck`     % Test,
-      Slf4j.`log4j-over-slf4j`   % Test,
-      Logback.core               % Test,
-      Logback.classic            % Test,
-      scalatest                  % Test,
+      TestContainers.cassandra % Test,
+      TestContainers.kafka     % Test,
+      scalatest                % Test,
+      Akka.`persistence-tck`   % Test,
+      Slf4j.`log4j-over-slf4j` % Test,
+      Logback.core             % Test,
+      Logback.classic          % Test,
+      scalatest                % Test,
     ),
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,27 +2,26 @@ import sbt.*
 
 object Dependencies {
 
-  val scalatest                  = "org.scalatest"          %% "scalatest"                      % "3.2.19"
-  val `scala-java8-compat`       = "org.scala-lang.modules" %% "scala-java8-compat"             % "1.0.2"
-  val `kind-projector`           = "org.typelevel"           % "kind-projector"                 % "0.13.3"
-  val `cassandra-driver`         = "com.datastax.cassandra"  % "cassandra-driver-core"          % "3.11.2"
-  val `play-json`                = "com.typesafe.play"      %% "play-json"                      % "2.9.3"
-  val `play-json-jsoniter`       = "com.evolution"          %% "play-json-jsoniter"             % "1.1.1"
-  val `executor-tools`           = "com.evolutiongaming"    %% "executor-tools"                 % "1.0.3"
-  val `akka-serialization`       = "com.evolutiongaming"    %% "akka-serialization"             % "1.1.0"
-  val `kafka-launcher`           = "com.evolutiongaming"    %% "kafka-launcher"                 % "0.2.0"
-  val `testcontainers-cassandra` = "com.dimafeng"           %% "testcontainers-scala-cassandra" % "0.43.0"
-  val hostname                   = "com.evolutiongaming"    %% "hostname"                       % "0.2.0"
-  val scassandra                 = "com.evolutiongaming"    %% "scassandra"                     % "5.3.0"
-  val `cassandra-sync`           = "com.evolutiongaming"    %% "cassandra-sync"                 % "3.0.0"
-  val `cats-helper`              = "com.evolutiongaming"    %% "cats-helper"                    % "3.11.3"
-  val random                     = "com.evolutiongaming"    %% "random"                         % "1.0.0"
-  val retry                      = "com.evolutiongaming"    %% "retry"                          % "3.0.1"
-  val sstream                    = "com.evolutiongaming"    %% "sstream"                        % "1.0.1"
-  val skafka                     = "com.evolutiongaming"    %% "skafka"                         % "17.1.3"
-  val `akka-test-actor`          = "com.evolutiongaming"    %% "akka-test-actor"                % "0.1.0"
-  val scache                     = "com.evolution"          %% "scache"                         % "5.1.3"
-  val `resource-pool`            = "com.evolution"          %% "resource-pool"                  % "1.0.5"
+  val scalatest            = "org.scalatest"          %% "scalatest"             % "3.2.19"
+  val `scala-java8-compat` = "org.scala-lang.modules" %% "scala-java8-compat"    % "1.0.2"
+  val `kind-projector`     = "org.typelevel"           % "kind-projector"        % "0.13.3"
+  val `cassandra-driver`   = "com.datastax.cassandra"  % "cassandra-driver-core" % "3.11.2"
+  val `kafka-clients`      = "org.apache.kafka"        % "kafka-clients"         % "3.4.0"
+  val `play-json`          = "com.typesafe.play"      %% "play-json"             % "2.9.3"
+  val `play-json-jsoniter` = "com.evolution"          %% "play-json-jsoniter"    % "1.1.1"
+  val `executor-tools`     = "com.evolutiongaming"    %% "executor-tools"        % "1.0.3"
+  val `akka-serialization` = "com.evolutiongaming"    %% "akka-serialization"    % "1.1.0"
+  val hostname             = "com.evolutiongaming"    %% "hostname"              % "0.2.0"
+  val scassandra           = "com.evolutiongaming"    %% "scassandra"            % "5.3.0"
+  val `cassandra-sync`     = "com.evolutiongaming"    %% "cassandra-sync"        % "3.0.0"
+  val `cats-helper`        = "com.evolutiongaming"    %% "cats-helper"           % "3.11.3"
+  val random               = "com.evolutiongaming"    %% "random"                % "1.0.0"
+  val retry                = "com.evolutiongaming"    %% "retry"                 % "3.0.1"
+  val sstream              = "com.evolutiongaming"    %% "sstream"               % "1.0.1"
+  val skafka               = "com.evolutiongaming"    %% "skafka"                % "17.1.3"
+  val `akka-test-actor`    = "com.evolutiongaming"    %% "akka-test-actor"       % "0.1.0"
+  val scache               = "com.evolution"          %% "scache"                % "5.1.3"
+  val `resource-pool`      = "com.evolution"          %% "resource-pool"         % "1.0.5"
 
   object Cats {
     val core   = "org.typelevel" %% "cats-core"   % "2.13.0"
@@ -51,12 +50,6 @@ object Dependencies {
     val slf4j             = "com.typesafe.akka" %% "akka-slf4j"           % version
   }
 
-  object Kafka {
-    private val version = "3.4.0"
-    val kafka           = "org.apache.kafka" %% "kafka"         % version
-    val `kafka-clients` = "org.apache.kafka"  % "kafka-clients" % version
-  }
-
   object Scodec {
     val core = "org.scodec" %% "scodec-core" % "1.11.7"
     val bits = "org.scodec" %% "scodec-bits" % "1.1.20"
@@ -79,5 +72,11 @@ object Dependencies {
     val core            = "io.circe" %% "circe-core"    % version
     val generic         = "io.circe" %% "circe-generic" % version
     val jawn            = "io.circe" %% "circe-jawn"    % version
+  }
+
+  object TestContainers {
+    private val version = "1.20.6"
+    val kafka           = "org.testcontainers" % "kafka"     % version
+    val cassandra       = "org.testcontainers" % "cassandra" % version
   }
 }


### PR DESCRIPTION
This will come in handy when we migrate to Scala 3:
- kafka-launcher starts Kafka in the same JVM and classpath as the KJ code, so we are tied to Kafka server's own Scala version support
- testcontainers Kafka starts in Docker, thus we are not tied anymore

Additionally:
- migrated from a Scala wrapper to using testcontainers directly - this way we can use the latest testcontainers version
- now Kafka and Cassandra start in parallel in tests
- test Cassandra and Kafka versions are now set explicitly