### PR TITLE
Prepare for Scala 3 support - easy code changes

### DIFF
--- a/circe/core/src/main/scala/com/evolutiongaming/kafka/journal/circe/package.scala
+++ b/circe/core/src/main/scala/com/evolutiongaming/kafka/journal/circe/package.scala
@@ -18,7 +18,7 @@ package object circe {
         values
           .toList
           .traverse { value => Eval.defer(convert(value)) }
-          .map(Json.arr(_: _*))
+          .map(Json.arr(_*))
       case JsObject(fields) =>
         fields
           .toList

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/FromAttempt.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/FromAttempt.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import com.evolutiongaming.kafka.journal.util.Fail
 import com.evolutiongaming.kafka.journal.util.Fail.implicits.*
-import scodec.Attempt
+import scodec.*
 
 import scala.util.Try
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/FromBytes.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/FromBytes.scala
@@ -3,8 +3,8 @@ package com.evolutiongaming.kafka.journal
 import cats.syntax.all.*
 import cats.{Applicative, Functor, Monad, ~>}
 import play.api.libs.json.*
+import scodec.*
 import scodec.bits.ByteVector
-import scodec.{Decoder, codecs}
 
 trait FromBytes[F[_], A] {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/LogOfFromAkka.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/LogOfFromAkka.scala
@@ -22,7 +22,7 @@ object LogOfFromAkka {
 
       def apply(source: String) = log(source)
 
-      def apply(source: Class[_]) = log(source)
+      def apply(source: Class[?]) = log(source)
     }
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Payload.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Payload.scala
@@ -3,9 +3,9 @@ package com.evolutiongaming.kafka.journal
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.*
 import play.api.libs.functional.syntax.*
 import play.api.libs.json.*
+import scodec.*
 import scodec.bits.ByteVector
 import scodec.codecs.{bytes, utf8}
-import scodec.{Codec, TransformSyntax}
 
 import scala.util.Try
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/PayloadMetadata.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/PayloadMetadata.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.implicits.none
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.formatCodec
 import play.api.libs.json.{JsValue, Json, OFormat}
-import scodec.Codec
+import scodec.*
 
 import scala.util.Try
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/ReleasedError.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/ReleasedError.scala
@@ -2,4 +2,4 @@ package com.evolutiongaming.kafka.journal
 
 import scala.util.control.NoStackTrace
 
-private[journal] final case object ReleasedError extends RuntimeException("released") with NoStackTrace
+private[journal] case object ReleasedError extends RuntimeException("released") with NoStackTrace

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/SeqNr.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/SeqNr.scala
@@ -9,7 +9,7 @@ import com.evolutiongaming.kafka.journal.util.PlayJsonHelper.*
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.*
 import com.evolutiongaming.scassandra.*
 import play.api.libs.json.*
-import scodec.{Attempt, Codec, codecs}
+import scodec.*
 
 sealed abstract case class SeqNr(value: Long) {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/Tags.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/Tags.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.kafka.journal
 
-import scodec.{Codec, codecs}
+import scodec.*
 
 private[journal] object Tags {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/ToBytes.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/ToBytes.scala
@@ -3,8 +3,8 @@ package com.evolutiongaming.kafka.journal
 import cats.syntax.all.*
 import cats.{Applicative, Contravariant, ~>}
 import play.api.libs.json.Writes
+import scodec.*
 import scodec.bits.ByteVector
-import scodec.{Encoder, codecs}
 
 trait ToBytes[F[_], -A] {
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/util/Fail.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/util/Fail.scala
@@ -6,7 +6,7 @@ import cats.syntax.all.*
 import com.evolutiongaming.catshelper.ApplicativeThrowable
 import com.evolutiongaming.kafka.journal.JournalError
 import play.api.libs.json.{JsError, JsResult}
-import scodec.{Attempt, Err}
+import scodec.*
 
 import scala.util.{Failure, Try}
 

--- a/core/src/main/scala/com/evolutiongaming/kafka/journal/util/ScodecHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/kafka/journal/util/ScodecHelper.scala
@@ -5,8 +5,8 @@ import cats.data.NonEmptyList as Nel
 import cats.syntax.all.*
 import com.evolutiongaming.kafka.journal.JsonCodec
 import play.api.libs.json.Format
+import scodec.*
 import scodec.bits.ByteVector
-import scodec.{Attempt, Codec, Err, codecs}
 
 import java.nio.charset.{CharacterCodingException, StandardCharsets}
 import scala.annotation.tailrec

--- a/core/src/test/scala/com/evolutiongaming/kafka/journal/ByteVectorOf.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/journal/ByteVectorOf.scala
@@ -8,7 +8,7 @@ import scodec.bits.ByteVector
 
 object ByteVectorOf {
 
-  def apply[F[_]: Monad: Fail](clazz: Class[_], path: String): F[ByteVector] = {
+  def apply[F[_]: Monad: Fail](clazz: Class[?], path: String): F[ByteVector] = {
     for {
       is <- Option(clazz.getResourceAsStream(path)).getOrError[F](s"file not found at $path")
     } yield {

--- a/core/src/test/scala/com/evolutiongaming/kafka/journal/util/ResourceRegistrySpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/kafka/journal/util/ResourceRegistrySpec.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.kafka.journal.util
 
 import cats.effect.{Deferred, Ref, *}
 import cats.syntax.all.*
-import cats.{Applicative, Foldable}
+import cats.{Applicative, Foldable, Monoid}
 import com.evolutiongaming.kafka.journal.IOSuite.*
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -37,7 +37,7 @@ class ResourceRegistrySpec extends AsyncFunSuite with Matchers {
       ResourceRegistry.make[IO].use { registry =>
         val resource = Resource.make(().pure[IO]) { _ => release }
         val fa = registry.allocate(resource)
-        implicit val monoidUnit = Applicative.monoid[IO, Unit]
+        implicit val monoidUnit: Monoid[IO[Unit]] = Applicative.monoid[IO, Unit]
         for {
           _ <- Foldable[List].fold(List.fill(n)(fa))
           _ <- error.fold(().pure[IO])(_.raiseError[IO, Unit])

--- a/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
+++ b/eventual-cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandra.scala
@@ -79,7 +79,7 @@ object EventualCassandra {
       statements <- Statements.of(schema, segmentNrsOf, Segments.default, consistencyConfig.read)
       _ <- log.info(s"kafka-journal version: ${ Version.current.value }")
     } yield {
-      implicit val log1 = log
+      implicit val log1: Log[F] = log
       val journal = apply[F](statements, dataIntegrity).withLog(log)
       metrics
         .fold(journal) { metrics => journal.withMetrics(metrics) }

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraTest.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/EventualCassandraTest.scala
@@ -53,7 +53,7 @@ class EventualCassandraTest extends AnyFunSuite with Matchers {
     segmentSize <- List(SegmentSize.min, SegmentSize.default, SegmentSize.max)
     segments <- List(Segments.min, Segments.old)
   } {
-    implicit val log = Log.empty[StateT]
+    implicit val log: Log[StateT] = Log.empty[StateT]
 
     val config = DataIntegrityConfig(
       seqNrUniqueness = true,

--- a/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
+++ b/eventual-cassandra/src/test/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/ReplicatedCassandraTest.scala
@@ -62,8 +62,8 @@ class ReplicatedCassandraTest extends AnyFunSuite with Matchers {
     val segmentNrsOf = SegmentNrs.Of[StateT](first = segmentsFirst, second = segmentsSecond)
     val segmentOfId = SegmentNr.Of[Id](segmentsFirst)
     val journal = {
-      implicit val parallel = Parallel.identity[StateT]
-      implicit val uuidGen = new UUIDGen[StateT] {
+      implicit val parallel: Parallel.Aux[StateT, StateT] = Parallel.identity[StateT]
+      implicit val uuidGen: UUIDGen[StateT] = new UUIDGen[StateT] {
         override def randomUUID = uuid.pure[StateT]
       }
       ReplicatedCassandra(

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Bounds.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Bounds.scala
@@ -22,7 +22,7 @@ import scala.util.Try
  * val res0: Bounds[Int] = 10..70
  * }}}
  */
-private[journal] sealed trait Bounds[+A]
+private[journal] sealed trait Bounds[A]
 
 private[journal] object Bounds {
   implicit def semigroupBounds[A: Order]: Semigroup[Bounds[A]] = { (a: Bounds[A], b: Bounds[A]) =>

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Events.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Events.scala
@@ -2,8 +2,8 @@ package com.evolutiongaming.kafka.journal
 
 import cats.data.NonEmptyList as Nel
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.*
+import scodec.*
 import scodec.bits.ByteVector
-import scodec.{Codec, TransformSyntax, ValueCodecEnrichedWithHListSupport, codecs}
 
 import java.lang.Byte as ByteJ
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Group.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Group.scala
@@ -20,10 +20,10 @@ object Group {
     sealed trait S
 
     object S {
-      final case object Idle extends S
+      case object Idle extends S
       final case class Busy(as: List[A], deferred: Deferred[F, Either[Throwable, B]]) extends S
       final case class Releasing(as: List[A], deferred: Deferred[F, Either[Throwable, B]]) extends S
-      final case object Released extends S
+      case object Released extends S
     }
 
     Resource
@@ -114,5 +114,5 @@ object Group {
       }
   }
 
-  final case object ReleasedError extends RuntimeException("released") with NoStackTrace
+  case object ReleasedError extends RuntimeException("released") with NoStackTrace
 }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadInfo.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadInfo.scala
@@ -114,7 +114,7 @@ object HeadInfo {
    *
    * In other words, one can read it from Cassandra only and not look into Kafka.
    */
-  final case object Empty extends HeadInfo
+  case object Empty extends HeadInfo
 
   /**
    * There are new non-replicated events in Kafka for specific journal.
@@ -194,7 +194,7 @@ object HeadInfo {
    *
    * It means there is no need to read either Cassandra or Kafka as journal was purged.
    */
-  final case object Purge extends NonEmpty
+  case object Purge extends NonEmpty
 
   implicit class HeadInfoOps(val self: HeadInfo) extends AnyVal {
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/Headers.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/Headers.scala
@@ -4,5 +4,5 @@ object Headers {
 
   val empty: Headers = Map.empty
 
-  def apply(headers: (String, String)*): Headers = Map(headers: _*)
+  def apply(headers: (String, String)*): Headers = Map(headers*)
 }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/JournalConfig.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/JournalConfig.scala
@@ -32,7 +32,7 @@ object JournalConfig {
   val default: JournalConfig = JournalConfig()
 
   implicit val configReaderJournalConfig: ConfigReader[JournalConfig] = {
-    implicit val configReaderKafkaConfig = KafkaConfig.configReader(default.kafka)
+    implicit val configReaderKafkaConfig: ConfigReader[KafkaConfig] = KafkaConfig.configReader(default.kafka)
     deriveReader[JournalConfig]
   }
 

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PartitionCache.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PartitionCache.scala
@@ -648,7 +648,7 @@ private[journal] object PartitionCache {
        *
        * In other words, the journal is already fully replicated to a long term storage.
        */
-      final case object Ahead extends Now
+      case object Ahead extends Now
 
       /**
        * [[HeadInfo]] was dropped because maximum cache size was reached.
@@ -656,7 +656,7 @@ private[journal] object PartitionCache {
        * In other words, [[PartitionCache]] has seen given offset in Kafka, but we could not return
        * a [[HeadInfo]] value to be used, and it has to be calcuated again.
        */
-      final case object Limited extends Now
+      case object Limited extends Now
 
       /**
        * The timeout occured while waiting for the [[HeadInfo]] value to load.
@@ -1038,7 +1038,7 @@ private[journal] object PartitionCache {
      * Same as [[PartitionCache#add]], but makes it a bit less verbose
      */
     def add(record: Record, records: Record*): F[Option[Diff]] = {
-      self.add(Nel.of(record, records: _*))
+      self.add(Nel.of(record, records*))
     }
   }
 }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PartitionOffset.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PartitionOffset.scala
@@ -39,7 +39,7 @@ object PartitionOffset {
   implicit val orderPartitionOffset: Order[PartitionOffset] =
     Order.whenEqual(Order.by { (a: PartitionOffset) => a.partition }, Order.by { (a: PartitionOffset) => a.offset })
 
-  def apply(record: ConsumerRecord[_, _]): PartitionOffset = {
+  def apply(record: ConsumerRecord[?, ?]): PartitionOffset = {
     PartitionOffset(partition = record.topicPartition.partition, offset = record.offset)
   }
 }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/PayloadAndType.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptyList as Nel
 import com.evolutiongaming.kafka.journal.util.PlayJsonHelper.*
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.*
 import play.api.libs.json.*
-import scodec.Codec
+import scodec.*
 import scodec.bits.ByteVector
 
 import scala.util.Try

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/ActionToProducerRecordSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/ActionToProducerRecordSpec.scala
@@ -1,10 +1,10 @@
 package com.evolutiongaming.kafka.journal
 
-import TestJsonCodec.instance
 import cats.data.NonEmptyList as Nel
 import cats.syntax.all.*
 import com.evolutiongaming.kafka.journal.ExpireAfter.implicits.*
-import com.evolutiongaming.kafka.journal.conversions.{ActionToProducerRecord, ConsRecordToActionRecord, KafkaWrite}
+import com.evolutiongaming.kafka.journal.TestJsonCodec.instance
+import com.evolutiongaming.kafka.journal.conversions.{ActionToProducerRecord, ConsRecordToActionRecord}
 import com.evolutiongaming.skafka.consumer.WithSize
 import com.evolutiongaming.skafka.{TimestampAndType, TimestampType, TopicPartition}
 import org.scalatest.funsuite.AnyFunSuite
@@ -87,7 +87,6 @@ class ActionToProducerRecordSpec extends AnyFunSuite with Matchers {
   }
 
   private val appends = {
-    implicit val kafkaWrite = KafkaWrite.summon[Try, Payload]
     for {
       origin <- origins
       version <- versions

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/EventsTest.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/EventsTest.scala
@@ -6,15 +6,15 @@ import com.evolutiongaming.kafka.journal.Event.*
 import com.evolutiongaming.kafka.journal.util.ScodecHelper.{nelCodec, *}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import scodec.*
 import scodec.bits.ByteVector
-import scodec.{Attempt, codecs}
 
 import scala.util.Try
 
 class EventsTest extends AnyFunSuite with Matchers {
 
   test("decode newer version") {
-    implicit val jsonCodec = JsonCodec.jsoniter[Try]
+    implicit val jsonCodec: JsonCodec[Try] = JsonCodec.jsoniter[Try]
     val codec = {
       val eventsCodec =
         nelCodec(codecs.listOfN(codecs.int32, codecs.variableSizeBytes(codecs.int32, Event.codecEventPayload)))

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/HeadCacheSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/HeadCacheSpec.scala
@@ -7,7 +7,7 @@ import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.Log
 import com.evolutiongaming.kafka.journal.IOSuite.*
 import com.evolutiongaming.kafka.journal.TestJsonCodec.instance
-import com.evolutiongaming.kafka.journal.conversions.{ActionToProducerRecord, KafkaWrite}
+import com.evolutiongaming.kafka.journal.conversions.ActionToProducerRecord
 import com.evolutiongaming.kafka.journal.eventual.TopicPointers
 import com.evolutiongaming.retry.Sleep
 import com.evolutiongaming.skafka.*
@@ -73,7 +73,7 @@ class HeadCacheSpec extends AsyncWordSpec with Matchers {
       val marker = Offset.unsafe(10)
 
       val pointers = Map((partition, marker))
-      implicit val eventual = HeadCache.Eventual.const(TopicPointers(pointers).pure[IO])
+      implicit val eventual: HeadCache.Eventual[IO] = HeadCache.Eventual.const(TopicPointers(pointers).pure[IO])
 
       val state = TestConsumer.State(topics = Map((topic, List(partition))))
 
@@ -258,7 +258,6 @@ object HeadCacheSpec {
   }
 
   def appendOf(key: Key, seqNr: SeqNr): Action.Append = {
-    implicit val kafkaWrite = KafkaWrite.summon[Try, Payload]
     Action
       .Append
       .of[Try, Payload](

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/JournalSpec.scala
@@ -43,7 +43,7 @@ class JournalSpec extends AnyWordSpec with Matchers {
         withJournal { journal =>
           def append(seqNrs: Nel[SeqNr]) = {
             journal
-              .append(seqNrs.head, seqNrs.tail: _*)
+              .append(seqNrs.head, seqNrs.tail*)
               .map { _.some }
           }
           for {
@@ -441,7 +441,7 @@ object JournalSpec {
 
         def append(seqNr: SeqNr, seqNrs: SeqNr*) = {
           val events = for {
-            seqNr <- Nel.of(seqNr, seqNrs: _*)
+            seqNr <- Nel.of(seqNr, seqNrs*)
           } yield {
             Event[A](seqNr)
           }
@@ -491,13 +491,13 @@ object JournalSpec {
       produceAction: ProduceAction[F],
       headCache: HeadCache[F],
     ): SeqNrJournal[F] = {
-      implicit val clock = Clock.const[F](nanos = 0, millis = timestamp.toEpochMilli)
-      implicit val randomIdOf = RandomIdOf.uuid[F]
-      implicit val measureDuration = MeasureDuration.fromClock(clock)
-      implicit val fromTry = FromTry.lift[F]
-      implicit val fail = Fail.lift[F]
-      implicit val fromAttempt = FromAttempt.lift[F]
-      implicit val fromJsResult = FromJsResult.lift[F]
+      implicit val clock: Clock[F] = Clock.const[F](nanos = 0, millis = timestamp.toEpochMilli)
+      implicit val randomIdOf: RandomIdOf[F] = RandomIdOf.uuid[F]
+      implicit val measureDuration: MeasureDuration[F] = MeasureDuration.fromClock(clock)
+      implicit val fromTry: FromTry[F] = FromTry.lift[F]
+      implicit val fail: Fail[F] = Fail.lift[F]
+      implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
+      implicit val fromJsResult: FromJsResult[F] = FromJsResult.lift[F]
       val log = Log.empty[F]
 
       val journal = Journals[F](
@@ -643,8 +643,8 @@ object JournalSpec {
 
       def apply(record: ActionRecord[Action], offset: Offset): State = {
 
-        implicit val fromAttempt = FromAttempt.lift[Try]
-        implicit val fromJsResult = FromJsResult.lift[Try]
+        implicit val fromAttempt: FromAttempt[Try] = FromAttempt.lift[Try]
+        implicit val fromJsResult: FromJsResult[Try] = FromJsResult.lift[Try]
 
         val kafkaRead = KafkaRead.summon[Try, Payload]
         val eventualWrite = EventualWrite.summon[Try, Payload]

--- a/journal/src/test/scala/com/evolutiongaming/kafka/journal/eventual/EventualJournalSpec.scala
+++ b/journal/src/test/scala/com/evolutiongaming/kafka/journal/eventual/EventualJournalSpec.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.kafka.journal.eventual
 import cats.data.NonEmptyList as Nel
 import cats.effect.Clock
 import cats.syntax.all.*
-import cats.{Applicative, FlatMap, Monad}
+import cats.{Applicative, FlatMap, Monad, Monoid}
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.catshelper.DataHelper.*
 import com.evolutiongaming.catshelper.{BracketThrowable, Log, MeasureDuration, MonadThrowable}
@@ -30,9 +30,9 @@ trait EventualJournalSpec extends AnyWordSpec with Matchers {
     val withJournals1 = (key: Key, timestamp: Instant) => { (f: (Eventual[F], Replicated[F]) => F[Assertion]) =>
       {
         withJournals { journals =>
-          implicit val log = Log.empty[F]
-          implicit val clock = Clock.const[F](nanos = 0, millis = 0)
-          implicit val measureDuration = MeasureDuration.fromClock(clock)
+          implicit val log: Log[F] = Log.empty[F]
+          implicit val clock: Clock[F] = Clock.const[F](nanos = 0, millis = 0)
+          implicit val measureDuration: MeasureDuration[F] = MeasureDuration.fromClock(clock)
           val eventual = {
             val journal = journals
               .eventual
@@ -61,7 +61,7 @@ trait EventualJournalSpec extends AnyWordSpec with Matchers {
     withJournals: (Key, Instant) => ((Eventual[F], Replicated[F]) => F[Assertion]) => F[Assertion],
   ): Unit = {
 
-    implicit val monoidUnit = Applicative.monoid[F, Unit]
+    implicit val monoidUnit: Monoid[F[Unit]] = Applicative.monoid[F, Unit]
 
     val key = EventualJournalSpec.key
 

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/JournalAdapter.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/JournalAdapter.scala
@@ -6,9 +6,9 @@ import cats.syntax.all.*
 import cats.{Monad, Parallel, ~>}
 import com.evolutiongaming.catshelper.*
 import com.evolutiongaming.kafka.journal.*
-import com.evolutiongaming.kafka.journal.conversions.ConversionMetrics
-import com.evolutiongaming.kafka.journal.eventual.EventualJournal
+import com.evolutiongaming.kafka.journal.conversions.{ConversionMetrics, KafkaRead, KafkaWrite}
 import com.evolutiongaming.kafka.journal.eventual.cassandra.EventualCassandra
+import com.evolutiongaming.kafka.journal.eventual.{EventualJournal, EventualRead}
 import com.evolutiongaming.kafka.journal.util.Fail
 import com.evolutiongaming.scassandra.CassandraClusterOf
 import com.evolutiongaming.scassandra.util.FromGFuture
@@ -123,9 +123,9 @@ object JournalAdapter {
     appendMetadataOf: AppendMetadataOf[F],
   ): JournalAdapter[F] = {
 
-    implicit val kafkaRead = journalReadWrite.kafkaRead
-    implicit val kafkaWrite = journalReadWrite.kafkaWrite
-    implicit val eventualRead = journalReadWrite.eventualRead
+    implicit val kafkaRead: KafkaRead[F, A] = journalReadWrite.kafkaRead
+    implicit val kafkaWrite: KafkaWrite[F, A] = journalReadWrite.kafkaWrite
+    implicit val eventualRead: EventualRead[F, A] = journalReadWrite.eventualRead
 
     new JournalAdapter[F] {
 

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
@@ -133,8 +133,8 @@ class KafkaJournal(config: Config) extends AsyncWriteJournal { actor =>
     for {
       jsonCodec <- jsonCodec(config)
     } yield {
-      implicit val jsonCodec1 = jsonCodec
-      implicit val jsonCodecTry = jsonCodec.mapK(ToTry.functionK)
+      implicit val jsonCodec1: JsonCodec[IO] = jsonCodec
+      implicit val jsonCodecTry: JsonCodec[Try] = jsonCodec.mapK(ToTry.functionK)
       JournalReadWrite.of[IO, Payload]
     }
   }

--- a/persistence/src/main/scala/akka/persistence/kafka/journal/PersistentBinary.scala
+++ b/persistence/src/main/scala/akka/persistence/kafka/journal/PersistentBinary.scala
@@ -3,7 +3,7 @@ package akka.persistence.kafka.journal
 import akka.persistence.PersistentRepr
 import com.evolutiongaming.kafka.journal.{FromAttempt, FromBytes, ToBytes}
 import com.evolutiongaming.serialization.SerializedMsg
-import scodec.{Codec, HListCodecEnrichedWithHListSupport, TransformSyntax, ValueCodecEnrichedWithHListSupport, codecs}
+import scodec.*
 
 final case class PersistentBinary(manifest: Option[String], writerUuid: String, payload: SerializedMsg)
 

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJob.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJob.scala
@@ -104,7 +104,7 @@ object DistributeJob {
 
       final case class Active(partitions: Map[Partition, Assigned], jobs: Map[String, (Job, Release)]) extends Allocated
 
-      final case object Released extends S
+      case object Released extends S
     }
 
     val unit = ().pure[F]

--- a/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
+++ b/replicator/src/main/scala/com/evolutiongaming/kafka/journal/replicator/PurgeExpired.scala
@@ -42,7 +42,7 @@ object PurgeExpired {
     consistencyConfig: CassandraConsistencyConfig.Read,
   ): Resource[F, PurgeExpired[F]] = {
 
-    implicit val fromAttempt = FromAttempt.lift[F]
+    implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
 
     for {
       producer <- Journals.Producer.make[F](producerConfig)

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ConsumeTopicTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ConsumeTopicTest.scala
@@ -169,7 +169,7 @@ object ConsumeTopicTest {
       IO.delay {
         var result: State = state
 
-        implicit val toTryStateT = new ToTry[StateT] {
+        implicit val toTryStateT: ToTry[StateT] = new ToTry[StateT] {
 
           val ioToTry = ToTry.ioToTry
 

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJobTest.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/DistributeJobTest.scala
@@ -23,8 +23,8 @@ class DistributeJobTest extends AsyncFunSuite with Matchers {
 
     def topicPartitionOf(partition: Partition) = TopicPartition(topic, partition)
 
-    implicit val logOf = LogOf.empty[IO]
-    implicit val toTry = ToTry.ioToTry
+    implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+    implicit val toTry: ToTry[IO] = ToTry.ioToTry
     val consumerConfig = ConsumerConfig()
     val result = for {
       actions <- Actions.of[IO]

--- a/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorSpec.scala
+++ b/replicator/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorSpec.scala
@@ -19,7 +19,7 @@ class ReplicatorSpec extends AsyncWordSpec with Matchers {
 
     "fail if any of replicators failed" in {
 
-      implicit val logOf = LogOf.empty[IO]
+      implicit val logOf: LogOf[IO] = LogOf.empty[IO]
 
       val error = new RuntimeException with NoStackTrace
 

--- a/tests/src/test/scala/akka/persistence/journal/PersistenceTckSerializer.scala
+++ b/tests/src/test/scala/akka/persistence/journal/PersistenceTckSerializer.scala
@@ -2,8 +2,8 @@ package akka.persistence.journal
 
 import akka.persistence.journal.JournalPerfSpec.Cmd
 import akka.serialization.SerializerWithStringManifest
+import scodec.*
 import scodec.bits.BitVector
-import scodec.{Codec, TransformSyntax, ValueCodecEnrichedWithHListSupport, codecs}
 
 import java.io.NotSerializableException
 

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/AppendReplicateApp.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/AppendReplicateApp.scala
@@ -31,7 +31,7 @@ object AppendReplicateApp extends IOApp {
 
     val config = ConfigFactory.load("AppendReplicate.conf")
     val system = ActorSystem("AppendReplicateApp", config)
-    implicit val measureDuration = MeasureDuration.fromClock(Clock[IO])
+    implicit val measureDuration: MeasureDuration[IO] = MeasureDuration.fromClock(Clock[IO])
 
     val topic = "journal.AppendReplicate"
 
@@ -45,8 +45,8 @@ object AppendReplicateApp extends IOApp {
     system: ActorSystem,
   ): F[Unit] = {
 
-    implicit val logOf = LogOfFromAkka[F](system)
-    implicit val randomIdOf = RandomIdOf.uuid[F]
+    implicit val logOf: LogOf[F] = LogOfFromAkka[F](system)
+    implicit val randomIdOf: RandomIdOf[F] = RandomIdOf.uuid[F]
 
     val kafkaJournalConfig = ConfigSource
       .fromConfig(system.settings.config)

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/IntegrationSuite.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/IntegrationSuite.scala
@@ -66,7 +66,7 @@ object IntegrationSuite {
     }
 
     def replicator(log: Log[F]) = {
-      implicit val kafkaConsumerOf = KafkaConsumerOf[F]()
+      implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()
       val config = for {
         config <- Sync[F].delay { ConfigFactory.load("replicator.conf") }
         config <- ReplicatorConfig.fromConfig[F](config)
@@ -95,7 +95,7 @@ object IntegrationSuite {
     for {
       logOf <- logOf.toResource
       result <- {
-        implicit val logOf1 = logOf
+        implicit val logOf1: LogOf[IO] = logOf
         startF[IO](cassandraClusterOf)
       }
     } yield result

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalIntSpec.scala
@@ -36,7 +36,7 @@ abstract class JournalIntSpec[A] extends AsyncWordSpec with JournalSuite {
 
   private val journalsOf = { (eventualJournal: EventualJournal[IO], headCache: Boolean) =>
     {
-      implicit val logOf = LogOf.empty[IO]
+      implicit val logOf: LogOf[IO] = LogOf.empty[IO]
       val log = Log.empty[IO]
 
       def headCacheOf(config: KafkaJournalConfig) = if (headCache) {

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalPerfSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalPerfSpec.scala
@@ -28,7 +28,7 @@ class JournalPerfSpec extends AsyncWordSpec with JournalSuite {
 
   private val journalOf = { (eventualJournal: EventualJournal[IO]) =>
     {
-      implicit val logOf = LogOf.empty[IO]
+      implicit val logOf: LogOf[IO] = LogOf.empty[IO]
       val log = Log.empty[IO]
       val headCacheOf = HeadCacheOf[IO](HeadCacheMetrics.empty[IO].some)
       for {

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalSuite.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/JournalSuite.scala
@@ -40,8 +40,8 @@ trait JournalSuite extends ActorSuite with Matchers { self: Suite =>
   implicit val randomIdOf: RandomIdOf[IO] = RandomIdOf.uuid[IO]
 
   lazy val ((eventualJournal, producer), release) = {
-    implicit val logOf = LogOf.empty[IO]
-    implicit val jsonCodec = JsonCodec.jsoniter[IO]
+    implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+    implicit val jsonCodec: JsonCodec[IO] = JsonCodec.jsoniter[IO]
     val resource = for {
       config <- config.liftTo[IO].toResource
       origin <- Origin.hostName[IO].toResource

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/ReadEventsApp.scala
@@ -32,10 +32,10 @@ object ReadEventsApp extends IOApp {
       logOf <- LogOf.slf4j[F]
       log <- logOf(ReadEventsApp.getClass)
       result <- {
-        implicit val logOf1 = logOf
-        implicit val measureDuration = MeasureDuration.fromClock(Clock[F])
-        implicit val fromAttempt = FromAttempt.lift[F]
-        implicit val fromJsResult = FromJsResult.lift[F]
+        implicit val logOf1: LogOf[F] = logOf
+        implicit val measureDuration: MeasureDuration[F] = MeasureDuration.fromClock(Clock[F])
+        implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
+        implicit val fromJsResult: FromJsResult[F] = FromJsResult.lift[F]
         runF[F](log).handleErrorWith { error =>
           log.error(s"failed with $error", error)
         }
@@ -51,12 +51,9 @@ object ReadEventsApp extends IOApp {
   ](
     log: Log[F],
   ): F[Unit] = {
-
-    implicit val kafkaConsumerOf = KafkaConsumerOf[F]()
-
-    implicit val kafkaProducerOf = KafkaProducerOf[F]()
-
-    implicit val randomIdOf = RandomIdOf.uuid[F]
+    implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()
+    implicit val kafkaProducerOf: KafkaProducerOf[F] = KafkaProducerOf[F]()
+    implicit val randomIdOf: RandomIdOf[F] = RandomIdOf.uuid[F]
 
     val commonConfig = CommonConfig(clientId = "ReadEventsApp".some, bootstrapServers = Nel.of("localhost:9092"))
 

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/SettingsIntSpec.scala
@@ -74,8 +74,7 @@ class SettingsIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matchers
   }
 
   def test[F[_]: Async: Parallel: FromFuture](cassandraClusterOf: CassandraClusterOf[F]): F[Unit] = {
-
-    implicit val logOf = LogOf.empty[F]
+    implicit val logOf: LogOf[F] = LogOf.empty[F]
 
     for {
       origin <- Origin.hostName[F]

--- a/tests/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -71,9 +71,8 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
         .load[JournalConfig]
         .liftTo[F]
 
-      implicit val kafkaConsumerOf = KafkaConsumerOf[F]()
-
-      implicit val kafkaProducerOf = KafkaProducerOf[F]()
+      implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()
+      implicit val kafkaProducerOf: KafkaProducerOf[F] = KafkaProducerOf[F]()
 
       for {
         config <- config.toResource
@@ -112,7 +111,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
   }
 
   lazy val ((eventualJournal, journals), release) = {
-    implicit val logOf = LogOf.empty[IO]
+    implicit val logOf: LogOf[IO] = LogOf.empty[IO]
     resources[IO](cassandraClusterOf).allocated.unsafeRunSync()
   }
 


### PR DESCRIPTION
- Remove final from case objects - not supported by Scala 3.
- Fix outdated Scala 2 syntax warnings.
- Add explicit types to implicit values - in many cases like this, Scala 3 doesn't compile.
- Make scodec imports Scala 3 friendly. Some things under scodec package changed for Scala 3, but if it is imported with * it works.
- Remove type arg variance where possible - Scala 3 doesn't like it in pattern-matching.