### PR TITLE
Prepare for Scala 3 support - more code changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies.*
+import com.typesafe.tools.mima.core.*
 import sbt.Package.ManifestAttributes
 
 lazy val commonSettings = Seq(
@@ -49,6 +50,11 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   //    ProblemFilters.exclude[IncompatibleMethTypeProblem](
   //      "com.evolutiongaming.kafka.journal.replicator.TopicReplicator#ConsumerOf.make",
   //    ),
+
+  // TODO: [next release after 4.2.1] remove
+  // package-private changes
+  ProblemFilters.exclude[Problem]("com.evolutiongaming.kafka.journal.PartitionCache$*"),
+  ProblemFilters.exclude[Problem]("com.evolutiongaming.kafka.journal.PartitionCache#*"),
 )
 
 val alias: Seq[sbt.Def.Setting[?]] =

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadCache.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/HeadCache.scala
@@ -174,10 +174,10 @@ object HeadCache {
                 .get(key.id, partition, offset)
                 .flatMap { _.toNow }
                 .map {
-                  case a: Result.Now.Value => a.value.some
-                  case Result.Now.Ahead => HeadInfo.empty.some
-                  case Result.Now.Limited => none
-                  case _: Result.Now.Timeout => none
+                  case a: Result.Now.Value[F] => a.value.some
+                  case _: Result.Now.Ahead[F] => HeadInfo.empty.some
+                  case _: Result.Now.Limited[F] => none
+                  case _: Result.Now.Timeout[F] => none
                 }
             }
         }

--- a/journal/src/main/scala/com/evolutiongaming/kafka/journal/TopicCache.scala
+++ b/journal/src/main/scala/com/evolutiongaming/kafka/journal/TopicCache.scala
@@ -522,12 +522,12 @@ private[journal] object TopicCache {
           import com.evolutiongaming.kafka.journal.PartitionCache.Result
           for {
             d <- MeasureDuration[F].start
-            f = (result: Either[Throwable, Result.Now], hit: Boolean) => {
+            f = (result: Either[Throwable, Result.Now[F]], hit: Boolean) => {
               val name = result match {
-                case Right(_: Result.Now.Value) => "value"
-                case Right(Result.Now.Ahead) => "ahead"
-                case Right(Result.Now.Limited) => "limited"
-                case Right(_: Result.Now.Timeout) => "timeout"
+                case Right(_: Result.Now.Value[F]) => "value"
+                case Right(_: Result.Now.Ahead[F]) => "ahead"
+                case Right(_: Result.Now.Limited[F]) => "limited"
+                case Right(_: Result.Now.Timeout[F]) => "timeout"
                 case Left(_) => "failure"
               }
               for {
@@ -540,7 +540,7 @@ private[journal] object TopicCache {
               .get(id, partition, offset)
               .attempt
             a <- a match {
-              case Right(a: Result.Now) =>
+              case Right(a: Result.Now[F]) =>
                 f(a.asRight, true)
 
               case Right(Result.Later.Behind(a)) =>


### PR DESCRIPTION
Remove type arg variance in PartitionCache.Result
as it trips out Scala 3 compiler in pattern-matching. Also having variance for F[_]-kind of type args
doesn't look right.