### PR TITLE
update skafka to 20.0.0 (and kafka-clients to 4.2.0)

### DIFF
--- a/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
+++ b/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
@@ -34,7 +34,7 @@ object JournalAdapter {
   def make[
     F[
       _,
-    ]: Async: ToFuture: Parallel: LogOf: RandomIdOf: FromGFuture: MeasureDuration: ToTry: FromTry: FromJsResult: Fail: JsonCodec,
+    ]: Async: Parallel: LogOf: RandomIdOf: FromGFuture: MeasureDuration: ToTry: FromTry: FromJsResult: Fail: JsonCodec,
     A,
   ](
     toKey: ToKey[F],

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/AppendReplicateApp.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/AppendReplicateApp.scala
@@ -39,7 +39,7 @@ object AppendReplicateApp extends IOApp {
     result.as(ExitCode.Success)
   }
 
-  private def runF[F[_]: Async: Parallel: ToFuture: FromGFuture: MeasureDuration: FromAttempt: FromTry: ToTry: Fail](
+  private def runF[F[_]: Async: Parallel: FromGFuture: MeasureDuration: FromAttempt: FromTry: ToTry: Fail](
     topic: Topic,
   )(implicit
     system: ActorSystem,

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -23,7 +23,7 @@ object IntegrationSuite {
   // Kafka version: 4.0.0 is too new to be the main test version, 3.9.0 container doesn't start
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:3.8.1")
 
-  def startF[F[_]: Async: ToFuture: LogOf: MeasureDuration: FromTry: ToTry: Fail](
+  def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ): Resource[F, Unit] = {
 

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
@@ -26,7 +26,7 @@ object ReadEventsApp extends IOApp {
     runF[IO].as(ExitCode.Success)
   }
 
-  private def runF[F[_]: Async: ToFuture: Parallel: FromGFuture: FromTry: ToTry: Fail]: F[Unit] = {
+  private def runF[F[_]: Async: Parallel: FromGFuture: FromTry: ToTry: Fail]: F[Unit] = {
 
     for {
       logOf <- LogOf.slf4j[F]
@@ -47,7 +47,7 @@ object ReadEventsApp extends IOApp {
   private def runF[
     F[
       _,
-    ]: Async: ToFuture: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
+    ]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
   ](
     log: Log[F],
   ): F[Unit] = {

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
@@ -45,9 +45,7 @@ object ReadEventsApp extends IOApp {
   }
 
   private def runF[
-    F[
-      _,
-    ]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
+    F[_]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
   ](
     log: Log[F],
   ): F[Unit] = {

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -43,7 +43,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
   private implicit val randomIdOf: RandomIdOf[IO] = RandomIdOf.uuid[IO]
 
   private def resources[
-    F[_]: Async: LogOf: Parallel: FromFuture: ToFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
+    F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
   ](
     cassandraClusterOf: CassandraClusterOf[F],
   ) = {

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -42,9 +42,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
 
   private implicit val randomIdOf: RandomIdOf[IO] = RandomIdOf.uuid[IO]
 
-  private def resources[
-    F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
-  ](
+  private def resources[F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ) = {
 

--- a/journal/src/main/scala/com/evolution/kafka/journal/KafkaConsumerOf.scala
+++ b/journal/src/main/scala/com/evolution/kafka/journal/KafkaConsumerOf.scala
@@ -1,7 +1,7 @@
 package com.evolution.kafka.journal
 
 import cats.effect.*
-import com.evolutiongaming.catshelper.{MeasureDuration, ToFuture, ToTry}
+import com.evolutiongaming.catshelper.{MeasureDuration, ToTry}
 import com.evolutiongaming.skafka
 import com.evolutiongaming.skafka.consumer.{ConsumerConfig, ConsumerMetrics, ConsumerOf}
 
@@ -22,7 +22,7 @@ object KafkaConsumerOf {
     F: KafkaConsumerOf[F],
   ): KafkaConsumerOf[F] = F
 
-  def apply[F[_]: Async: ToTry: ToFuture: MeasureDuration](
+  def apply[F[_]: Async: ToTry: MeasureDuration](
     metrics: Option[ConsumerMetrics[F]] = None,
   ): KafkaConsumerOf[F] = {
 

--- a/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
+++ b/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
@@ -34,7 +34,7 @@ object JournalAdapter {
   def make[
     F[
       _,
-    ]: Async: ToFuture: Parallel: LogOf: RandomIdOf: FromGFuture: MeasureDuration: ToTry: FromTry: FromJsResult: Fail: JsonCodec,
+    ]: Async: Parallel: LogOf: RandomIdOf: FromGFuture: MeasureDuration: ToTry: FromTry: FromJsResult: Fail: JsonCodec,
     A,
   ](
     toKey: ToKey[F],

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/AppendReplicateApp.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/AppendReplicateApp.scala
@@ -39,7 +39,7 @@ object AppendReplicateApp extends IOApp {
     result.as(ExitCode.Success)
   }
 
-  private def runF[F[_]: Async: Parallel: ToFuture: FromGFuture: MeasureDuration: FromAttempt: FromTry: ToTry: Fail](
+  private def runF[F[_]: Async: Parallel: FromGFuture: MeasureDuration: FromAttempt: FromTry: ToTry: Fail](
     topic: Topic,
   )(implicit
     system: ActorSystem,

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -23,7 +23,7 @@ object IntegrationSuite {
   // Kafka version: 4.0.0 is too new to be the main test version, 3.9.0 container doesn't start
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:3.8.1")
 
-  def startF[F[_]: Async: ToFuture: LogOf: MeasureDuration: FromTry: ToTry: Fail](
+  def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ): Resource[F, Unit] = {
 

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
@@ -26,7 +26,7 @@ object ReadEventsApp extends IOApp {
     runF[IO].as(ExitCode.Success)
   }
 
-  private def runF[F[_]: Async: ToFuture: Parallel: FromGFuture: FromTry: ToTry: Fail]: F[Unit] = {
+  private def runF[F[_]: Async: Parallel: FromGFuture: FromTry: ToTry: Fail]: F[Unit] = {
 
     for {
       logOf <- LogOf.slf4j[F]
@@ -47,7 +47,7 @@ object ReadEventsApp extends IOApp {
   private def runF[
     F[
       _,
-    ]: Async: ToFuture: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
+    ]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
   ](
     log: Log[F],
   ): F[Unit] = {

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/ReadEventsApp.scala
@@ -45,9 +45,7 @@ object ReadEventsApp extends IOApp {
   }
 
   private def runF[
-    F[
-      _,
-    ]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
+    F[_]: Async: Parallel: LogOf: FromGFuture: MeasureDuration: FromTry: ToTry: FromAttempt: FromJsResult: Fail,
   ](
     log: Log[F],
   ): F[Unit] = {

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -43,7 +43,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
   private implicit val randomIdOf: RandomIdOf[IO] = RandomIdOf.uuid[IO]
 
   private def resources[
-    F[_]: Async: LogOf: Parallel: FromFuture: ToFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
+    F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
   ](
     cassandraClusterOf: CassandraClusterOf[F],
   ) = {

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/replicator/ReplicatorIntSpec.scala
@@ -42,9 +42,7 @@ class ReplicatorIntSpec extends AsyncWordSpec with BeforeAndAfterAll with Matche
 
   private implicit val randomIdOf: RandomIdOf[IO] = RandomIdOf.uuid[IO]
 
-  private def resources[
-    F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail,
-  ](
+  private def resources[F[_]: Async: LogOf: Parallel: FromFuture: RandomIdOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ) = {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val ScalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
   val KindProjector = "org.typelevel" % "kind-projector" % "0.13.4"
   val CassandraDriver = "com.datastax.cassandra" % "cassandra-driver-core" % "3.11.5"
-  val KafkaClients = "org.apache.kafka" % "kafka-clients" % "3.9.2"
+  val KafkaClients = "org.apache.kafka" % "kafka-clients" % "4.2.0"
   val PlayJson = "com.typesafe.play" %% "play-json" % "2.10.8"
 
   private val PekkoExtensionVersion = "2.0.1"
@@ -20,7 +20,7 @@ object Dependencies {
   val Random = "com.evolution" %% "random" % "1.0.5"
   val Retry = "com.evolutiongaming" %% "retry" % "3.1.0"
   val SStream = "com.evolutiongaming" %% "sstream" % "1.1.0"
-  val SKafka = "com.evolutiongaming" %% "skafka" % "19.1.0"
+  val SKafka = "com.evolutiongaming" %% "skafka" % "20.0.0"
   val AkkaTestActor = "com.evolutiongaming" %% "akka-test-actor" % "0.3.0"
   val PekkoTestActor = "com.evolution" %% "pekko-extension-test-actor" % PekkoExtensionVersion
   val SCache = "com.evolution" %% "scache" % "6.0.1"

--- a/replicator/src/test/scala/com/evolution/kafka/journal/replicator/EmptyRebalanceConsumer.scala
+++ b/replicator/src/test/scala/com/evolution/kafka/journal/replicator/EmptyRebalanceConsumer.scala
@@ -91,4 +91,6 @@ trait EmptyRebalanceConsumer extends RebalanceConsumer {
 
   override def subscription(): Try[Set[Topic]] = Failure(new NotImplementedError)
 
+  override def currentLag(partition: TopicPartition): Try[Option[Long]] = Failure(new NotImplementedError)
+
 }


### PR DESCRIPTION
Major updates:
* skafka to 20.0.0
* kafka-clients to 4.2.0
* in few places API signature changes (removal of implicit `ToFuture` type class)
