### PR TITLE
Extend trait Journal with mark operation

### DIFF
--- a/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
+++ b/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
@@ -223,6 +223,12 @@ object JournalAdapterSpec {
             (state1, none[PartitionOffset])
           }
         }
+
+        def mark(id: String): StateT[PartitionOffset] = {
+          StateT { state =>
+            (state, partitionOffset)
+          }
+        }
       }
     }
 

--- a/journal/src/main/scala/com/evolution/kafka/journal/Journal.scala
+++ b/journal/src/main/scala/com/evolution/kafka/journal/Journal.scala
@@ -48,6 +48,16 @@ trait Journal[F[_]] {
    * key, consecutive pointer call will return `None`. Mostly used by [[PurgeExpired]].
    */
   def purge: F[Option[PartitionOffset]]
+
+  /**
+   * Produces a `mark` action with the given correlation id, returning the partition/offset where
+   * the mark was produced.
+   *
+   * Intended for clients that need to observe replication of preceding actions externally, by
+   * subscribing to marks in the replicated topic. The `id` should be unique per use case (callers
+   * are responsible for generating an id with sufficient entropy).
+   */
+  def mark(id: String): F[PartitionOffset]
 }
 
 object Journal {
@@ -77,6 +87,8 @@ object Journal {
       def delete(to: DeleteTo): F[Option[PartitionOffset]] = none[PartitionOffset].pure[F]
 
       def purge: F[Option[PartitionOffset]] = none[PartitionOffset].pure[F]
+
+      def mark(id: String): F[PartitionOffset] = PartitionOffset.empty.pure[F]
     }
   }
 
@@ -175,6 +187,15 @@ object Journal {
             _ <- logDebugOrWarn(d, config.purge) { s"$key purge in ${ d.toMillis }ms, result: $r" }
           } yield r
         }
+
+        def mark(id: String): F[PartitionOffset] = {
+          for {
+            d <- MeasureDuration[F].start
+            r <- self.mark(id)
+            d <- d
+            _ <- logDebugOrWarn(d, config.mark) { s"$key mark in ${ d.toMillis }ms, id: $id, result: $r" }
+          } yield r
+        }
       }
     }
 
@@ -254,6 +275,14 @@ object Journal {
             self.purge
           } { (error, latency) =>
             s"$key purge failed in ${ latency.toMillis }ms, error: $error"
+          }
+        }
+
+        def mark(id: String): F[PartitionOffset] = {
+          logError {
+            self.mark(id)
+          } { (error, latency) =>
+            s"$key mark failed in ${ latency.toMillis }ms, id: $id, error: $error"
           }
         }
       }
@@ -344,6 +373,15 @@ object Journal {
             _ <- metrics.purge(topic, d)
           } yield r
         }
+
+        def mark(id: String): F[PartitionOffset] = {
+          for {
+            d <- MeasureDuration[F].start
+            r <- handleError("mark", topic) { self.mark(id) }
+            d <- d
+            _ <- metrics.mark(topic, d)
+          } yield r
+        }
       }
     }
 
@@ -373,6 +411,8 @@ object Journal {
         def delete(to: DeleteTo): G[Option[PartitionOffset]] = fg(self.delete(to))
 
         def purge: G[Option[PartitionOffset]] = fg(self.purge)
+
+        def mark(id: String): G[PartitionOffset] = fg(self.mark(id))
       }
     }
   }
@@ -383,6 +423,7 @@ object Journal {
     pointer: FiniteDuration = 1.second,
     delete: FiniteDuration = 1.second,
     purge: FiniteDuration = 1.second,
+    mark: FiniteDuration = 1.second,
   )
 
   object CallTimeThresholds {

--- a/journal/src/main/scala/com/evolution/kafka/journal/JournalMetrics.scala
+++ b/journal/src/main/scala/com/evolution/kafka/journal/JournalMetrics.scala
@@ -23,6 +23,8 @@ trait JournalMetrics[F[_]] {
 
   def purge(topic: Topic, latency: FiniteDuration): F[Unit]
 
+  def mark(topic: Topic, latency: FiniteDuration): F[Unit]
+
   def failure(topic: Topic, name: String): F[Unit]
 }
 
@@ -45,6 +47,8 @@ object JournalMetrics {
       def delete(topic: Topic, latency: FiniteDuration): F[Unit] = unit
 
       def purge(topic: Topic, latency: FiniteDuration): F[Unit] = unit
+
+      def mark(topic: Topic, latency: FiniteDuration): F[Unit] = unit
 
       def failure(topic: Topic, name: String): F[Unit] = unit
     }
@@ -120,6 +124,10 @@ object JournalMetrics {
 
         def purge(topic: Topic, latency: FiniteDuration): F[Unit] = {
           observeLatency(name = "purge", topic = topic, latency = latency)
+        }
+
+        def mark(topic: Topic, latency: FiniteDuration): F[Unit] = {
+          observeLatency(name = "mark", topic = topic, latency = latency)
         }
 
         def failure(topic: Topic, name: String): F[Unit] = {

--- a/journal/src/main/scala/com/evolution/kafka/journal/Journals.scala
+++ b/journal/src/main/scala/com/evolution/kafka/journal/Journals.scala
@@ -336,6 +336,10 @@ object Journals {
               .purge(key)
               .map { _.some }
           }
+
+          def mark(id: String): F[PartitionOffset] = {
+            produce.mark(key, RandomId(id))
+          }
         }
       }
     }

--- a/journal/src/test/scala/com/evolution/kafka/journal/JournalSpec.scala
+++ b/journal/src/test/scala/com/evolution/kafka/journal/JournalSpec.scala
@@ -139,6 +139,19 @@ class JournalSpec extends AnyWordSpec with Matchers {
         }
       }
 
+      s"mark, $name" in {
+        createAndAppend {
+          case (journal, _) =>
+            for {
+              _ <- journal.mark("test-mark-id")
+              a <- journal.read(SeqRange.all)
+              _ = a shouldEqual seqNrs
+              a <- journal.pointer
+              _ = a shouldEqual seqNrLast
+            } yield Succeeded
+        }
+      }
+
       s"lastSeqNr, $name" in {
         createAndAppend {
           case (journal, _) =>
@@ -243,6 +256,37 @@ class JournalSpec extends AnyWordSpec with Matchers {
           a shouldEqual List(SeqNr.unsafe(2))
         }
       }
+    }
+  }
+
+  "Journal.mark" should {
+    "produce an Action.Mark with the supplied id" in {
+      implicit val clock: Clock[StateT] = Clock.const[StateT](nanos = 0, millis = timestamp.toEpochMilli)
+      implicit val randomIdOf: RandomIdOf[StateT] = RandomIdOf.uuid[StateT]
+      implicit val measureDuration: MeasureDuration[StateT] = MeasureDuration.fromClock(clock)
+      val log = Log.empty[StateT]
+
+      val journals = Journals[StateT](
+        eventual = StateT.eventualJournal,
+        consumeActionRecords = StateT.consumeActionRecords,
+        produce = Produce(StateT.produceAction, none),
+        headCache = StateT.headCache,
+        log = log,
+        conversionMetrics = none,
+      )
+
+      val (state, partitionOffset) = journals(JournalSpec.key)
+        .mark("custom-purge-id")
+        .run(State.empty)
+        .unsafeRunSync()
+
+      val ids = state
+        .records
+        .toList
+        .collect { case ActionRecord(a: Action.Mark, _) => a.id }
+
+      ids shouldEqual List("custom-purge-id")
+      partitionOffset.partition shouldEqual partition
     }
   }
 
@@ -414,6 +458,8 @@ object JournalSpec {
     def delete(to: DeleteTo): F[Option[Offset]]
 
     def purge: F[Option[Offset]]
+
+    def mark(id: String): F[Offset]
   }
 
   object SeqNrJournal {
@@ -482,6 +528,14 @@ object JournalSpec {
             } yield {
               partitionOffset.offset
             }
+        }
+
+        def mark(id: String): F[Offset] = {
+          for {
+            partitionOffset <- journal.mark(id)
+          } yield {
+            partitionOffset.offset
+          }
         }
       }
     }

--- a/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
+++ b/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
@@ -223,6 +223,12 @@ object JournalAdapterSpec {
             (state1, none[PartitionOffset])
           }
         }
+
+        def mark(id: String): StateT[PartitionOffset] = {
+          StateT { state =>
+            (state, partitionOffset)
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Currently mark actions are produced for synchronization only during actor recoveries. This allows using mark actions for synchronization in other contexts when it is important that all preceding events have been consumed.