### PR TITLE
Migrate build to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
         run: sbt ++${{ matrix.scala }} clean check
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt ++${{ matrix.scala }} clean coverage test coverageAggregate
 
       - name: test coverage
         if: success()
-        run: sbt ++${{ matrix.scala }} coverageAggregate coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
+        uses: coverallsapp/github-action@v2
+        with:
+          file: target/out/jvm/scala-${{ matrix.scala }}/kafka-journal-root/coverage-report/cobertura.xml
+          format: cobertura
+          flag-name: Scala ${{ matrix.scala }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: check code ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean check
+        run: sbt "++${{ matrix.scala }}; clean; check"
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test coverageAggregate
+        run: sbt "++${{ matrix.scala }}; clean; coverage; test; coverageAggregate"
 
       - name: test coverage
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,15 @@ jobs:
       - name: build ${{ matrix.scala }}
         run: sbt "++${{ matrix.scala }}; clean; coverage; test; coverageAggregate"
 
+      - name: locate coverage report
+        id: coverage
+        if: success()
+        run: echo "file=$(find . -path '*/coverage-report/cobertura.xml' | head -1)" >> "$GITHUB_OUTPUT"
+
       - name: test coverage
         if: success()
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
-          file: target/out/jvm/scala-${{ matrix.scala }}/kafka-journal-root/coverage-report/cobertura.xml
+          file: ${{ steps.coverage.outputs.file }}
           format: cobertura
           flag-name: Scala ${{ matrix.scala }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: test coverage
         if: success()
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           file: target/out/jvm/scala-${{ matrix.scala }}/kafka-journal-root/coverage-report/cobertura.xml
           format: cobertura

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,3 @@
+# The akka and pekko test suites are intentional mirrors of each other, so many
+# test sources are duplicated by design. Exclude test sources from copy-paste detection.
+sonar.cpd.exclusions=**/src/test/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,3 @@
-# The akka and pekko test suites are intentional mirrors of each other, so many
-# test sources are duplicated by design. Exclude test sources from copy-paste detection.
-sonar.cpd.exclusions=**/src/test/**
+# The akka and pekko test suites are intentional mirrors of each other, so their
+# test sources are duplicated by design. Exclude only those from copy-paste detection.
+sonar.cpd.exclusions=akka/tests/src/test/**,pekko/tests/src/test/**

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -33,70 +33,74 @@ object IntegrationSuite {
     }
     def loop(t: Throwable): Boolean =
       indicatesPortInUse(t) ||
-        (t.getCause match {
-          case null => false
-          case cause if cause eq t => false
-          case cause => loop(cause)
+        (Option(t.getCause) match {
+          case Some(cause) if cause ne t => loop(cause)
+          case _ => false
         })
     loop(error)
   }
+
+  private def startContainer[F[_]: Sync, C <: GenericContainer[C]](
+    exposeStaticPort: Int,
+  )(
+    makeContainer: => C,
+  ): F[C] =
+    Sync[F]
+      .blocking {
+        makeContainer.withCreateContainerCmdModifier { cmd =>
+          cmd.withHostConfig(
+            new HostConfig()
+              .withPortBindings(new PortBinding(
+                Ports.Binding.bindPort(exposeStaticPort),
+                new ExposedPort(exposeStaticPort),
+              )),
+          )
+          ()
+        }
+      }
+      .flatMap { container =>
+        Sync[F]
+          .blocking { container.start() }
+          .as(container)
+          // remove the partially-created container so a retry can rebind the port
+          .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+      }
+
+  // The containers bind fixed host ports, so only one test module can use them at a time.
+  // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+  // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+  // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+  // seconds after that JVM exits, so retry startup while the port is still held.
+  private def startContainerWithRetry[F[_]: Async, C <: GenericContainer[C]](
+    log: Log[F],
+    exposeStaticPort: Int,
+    attemptsLeft: Int,
+  )(
+    makeContainer: => C,
+  ): F[C] =
+    startContainer(exposeStaticPort)(makeContainer).handleErrorWith { error =>
+      if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
+      else
+        log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+          Temporal[F].sleep(3.seconds) *>
+          startContainerWithRetry(log, exposeStaticPort, attemptsLeft - 1)(makeContainer)
+    }
 
   private def testContainer[F[_]: Async, C <: GenericContainer[C]](
     log: Log[F],
     exposeStaticPort: Int,
   )(
     makeContainer: => C,
-  ): Resource[F, Unit] = {
-
-    def startContainer: F[C] =
-      Sync[F]
-        .blocking {
-          makeContainer.withCreateContainerCmdModifier { cmd =>
-            cmd.withHostConfig(
-              new HostConfig()
-                .withPortBindings(new PortBinding(
-                  Ports.Binding.bindPort(exposeStaticPort),
-                  new ExposedPort(exposeStaticPort),
-                )),
-            )
-            ()
-          }
-        }
-        .flatMap { container =>
-          Sync[F]
-            .blocking { container.start() }
-            .as(container)
-            // remove the partially-created container so a retry can rebind the port
-            .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-        }
-
-    // The containers bind fixed host ports, so only one test module can use them at a time.
-    // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-    // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-    // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-    // seconds after that JVM exits, so retry startup while the port is still held.
-    def startContainerWithRetry(attemptsLeft: Int): F[C] =
-      startContainer.handleErrorWith { error =>
-        if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-        else
-          log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-            Temporal[F].sleep(3.seconds) *>
-            startContainerWithRetry(attemptsLeft - 1)
-      }
-
+  ): Resource[F, Unit] =
     Resource
       .make {
-        startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+        startContainerWithRetry(log, exposeStaticPort, attemptsLeft = 20)(makeContainer) // ~1 minute total
       } { container =>
         Sync[F]
           .blocking { container.stop() }
-          .onError {
-            case t =>
-              log.error(s"failed to stop $container: ${ t.getMessage }", t)
-          }
+          .onError { case t => log.error(s"failed to stop $container: ${ t.getMessage }", t) }
       }
       .void
-  }
 
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -25,6 +25,79 @@ object IntegrationSuite {
   // Kafka version: 4.0.0 is too new to be the main test version, 3.9.0 container doesn't start
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:3.8.1")
 
+  // Whether the throwable (or any cause in its chain) is a "host port already taken" failure.
+  private def portInUse(error: Throwable): Boolean = {
+    def indicatesPortInUse(t: Throwable): Boolean = {
+      val message = Option(t.getMessage).fold("")(_.toLowerCase)
+      message.contains("already allocated") || message.contains("already in use")
+    }
+    def loop(t: Throwable): Boolean =
+      indicatesPortInUse(t) ||
+        (t.getCause match {
+          case null => false
+          case cause if cause eq t => false
+          case cause => loop(cause)
+        })
+    loop(error)
+  }
+
+  private def testContainer[F[_]: Async, C <: GenericContainer[C]](
+    log: Log[F],
+    exposeStaticPort: Int,
+  )(
+    makeContainer: => C,
+  ): Resource[F, Unit] = {
+
+    def startContainer: F[C] =
+      Sync[F]
+        .blocking {
+          makeContainer.withCreateContainerCmdModifier { cmd =>
+            cmd.withHostConfig(
+              new HostConfig()
+                .withPortBindings(new PortBinding(
+                  Ports.Binding.bindPort(exposeStaticPort),
+                  new ExposedPort(exposeStaticPort),
+                )),
+            )
+            ()
+          }
+        }
+        .flatMap { container =>
+          Sync[F]
+            .blocking { container.start() }
+            .as(container)
+            // remove the partially-created container so a retry can rebind the port
+            .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+        }
+
+    // The containers bind fixed host ports, so only one test module can use them at a time.
+    // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+    // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+    // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+    // seconds after that JVM exits, so retry startup while the port is still held.
+    def startContainerWithRetry(attemptsLeft: Int): F[C] =
+      startContainer.handleErrorWith { error =>
+        if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
+        else
+          log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+            Temporal[F].sleep(3.seconds) *>
+            startContainerWithRetry(attemptsLeft - 1)
+      }
+
+    Resource
+      .make {
+        startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+      } { container =>
+        Sync[F]
+          .blocking { container.stop() }
+          .onError {
+            case t =>
+              log.error(s"failed to stop $container: ${ t.getMessage }", t)
+          }
+      }
+      .void
+  }
+
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ): Resource[F, Unit] = {
@@ -34,78 +107,6 @@ object IntegrationSuite {
 
     def kafkaContainer(log: Log[F]): Resource[F, Unit] =
       testContainer(log, exposeStaticPort = 9092)(new KafkaContainer(KafkaDockerImage))
-
-    def testContainer[C <: GenericContainer[C]](
-      log: Log[F],
-      exposeStaticPort: Int,
-    )(
-      makeContainer: => C,
-    ): Resource[F, Unit] = {
-
-      def startContainer: F[C] =
-        Sync[F]
-          .blocking {
-            makeContainer.withCreateContainerCmdModifier { cmd =>
-              cmd.withHostConfig(
-                new HostConfig()
-                  .withPortBindings(new PortBinding(
-                    Ports.Binding.bindPort(exposeStaticPort),
-                    new ExposedPort(exposeStaticPort),
-                  )),
-              )
-              ()
-            }
-          }
-          .flatMap { container =>
-            Sync[F]
-              .blocking { container.start() }
-              .as(container)
-              // remove the partially-created container so a retry can rebind the port
-              .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-          }
-
-      // The containers bind fixed host ports, so only one test module can use them at a time.
-      // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-      // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-      // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-      // seconds after that JVM exits, so retry startup while the port is still held.
-      def portInUse(error: Throwable): Boolean = {
-        @annotation.tailrec
-        def loop(t: Throwable): Boolean = {
-          val message = Option(t.getMessage).fold("")(_.toLowerCase)
-          if (message.contains("already allocated") || message.contains("already in use")) true
-          else
-            t.getCause match {
-              case null => false
-              case cause if cause eq t => false
-              case cause => loop(cause)
-            }
-        }
-        loop(error)
-      }
-
-      def startContainerWithRetry(attemptsLeft: Int): F[C] =
-        startContainer.handleErrorWith { error =>
-          if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-          else
-            log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-              Temporal[F].sleep(3.seconds) *>
-              startContainerWithRetry(attemptsLeft - 1)
-        }
-
-      Resource
-        .make {
-          startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
-        } { container =>
-          Sync[F]
-            .blocking { container.stop() }
-            .onError {
-              case t =>
-                log.error(s"failed to stop $container: ${ t.getMessage }", t)
-            }
-        }
-        .void
-    }
 
     def replicator(log: Log[F]) = {
       implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -17,6 +17,8 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
+import scala.concurrent.duration.*
+
 object IntegrationSuite {
   // Cassandra version: latest 4.x
   private val CassandraDockerImage = DockerImageName.parse("cassandra:4.1.8")
@@ -39,7 +41,8 @@ object IntegrationSuite {
     )(
       makeContainer: => C,
     ): Resource[F, Unit] = {
-      Resource.make {
+
+      def startContainer: F[C] =
         Sync[F].blocking {
           val container = makeContainer
             .withCreateContainerCmdModifier { cmd =>
@@ -55,14 +58,33 @@ object IntegrationSuite {
           container.start()
           container
         }
-      } { container =>
-        Sync[F]
-          .blocking { container.stop() }
-          .onError {
-            case t =>
-              log.error(s"failed to stop $container: ${ t.getMessage }", t)
-          }
-      }.void
+
+      // The containers bind fixed host ports, so only one test module can use them at a time.
+      // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+      // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+      // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+      // seconds after that JVM exits, so retry startup for a while to let the port become free.
+      def startContainerWithRetry(attemptsLeft: Int): F[C] =
+        startContainer.handleErrorWith { error =>
+          if (attemptsLeft <= 1) error.raiseError[F, C]
+          else
+            log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+              Temporal[F].sleep(3.seconds) *>
+              startContainerWithRetry(attemptsLeft - 1)
+        }
+
+      Resource
+        .make {
+          startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+        } { container =>
+          Sync[F]
+            .blocking { container.stop() }
+            .onError {
+              case t =>
+                log.error(s"failed to stop $container: ${ t.getMessage }", t)
+            }
+        }
+        .void
     }
 
     def replicator(log: Log[F]) = {

--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -43,9 +43,9 @@ object IntegrationSuite {
     ): Resource[F, Unit] = {
 
       def startContainer: F[C] =
-        Sync[F].blocking {
-          val container = makeContainer
-            .withCreateContainerCmdModifier { cmd =>
+        Sync[F]
+          .blocking {
+            makeContainer.withCreateContainerCmdModifier { cmd =>
               cmd.withHostConfig(
                 new HostConfig()
                   .withPortBindings(new PortBinding(
@@ -55,18 +55,38 @@ object IntegrationSuite {
               )
               ()
             }
-          container.start()
-          container
-        }
+          }
+          .flatMap { container =>
+            Sync[F]
+              .blocking { container.start() }
+              .as(container)
+              // remove the partially-created container so a retry can rebind the port
+              .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+          }
 
       // The containers bind fixed host ports, so only one test module can use them at a time.
       // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
       // before shutdown hooks run, so the previous module's cleanup fails to stop its container
       // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-      // seconds after that JVM exits, so retry startup for a while to let the port become free.
+      // seconds after that JVM exits, so retry startup while the port is still held.
+      def portInUse(error: Throwable): Boolean = {
+        @annotation.tailrec
+        def loop(t: Throwable): Boolean = {
+          val message = Option(t.getMessage).fold("")(_.toLowerCase)
+          if (message.contains("already allocated") || message.contains("already in use")) true
+          else
+            t.getCause match {
+              case null => false
+              case cause if cause eq t => false
+              case cause => loop(cause)
+            }
+        }
+        loop(error)
+      }
+
       def startContainerWithRetry(attemptsLeft: Int): F[C] =
         startContainer.handleErrorWith { error =>
-          if (attemptsLeft <= 1) error.raiseError[F, C]
+          if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
           else
             log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
               Temporal[F].sleep(3.seconds) *>

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val commonSettings = Seq(
   ),
   scalacOptions ++= crossSettings(
     scalaVersion = scalaVersion.value,
-    // Good compiler options for Scala 2.13 are coming from com.evolution:sbt-scalac-opts-plugin:0.0.9,
+    // Good compiler options for Scala 2.13 are coming from com.evolution:sbt-scalac-opts-plugin:0.1.0,
     // but its support for Scala 3 is limited, especially what concerns linting options.
     //
     // If Scala 3 is made the primary target, good linting scalac options for it should be added first.
@@ -37,6 +37,9 @@ lazy val commonSettings = Seq(
   ),
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
+  // -Wnonunit-statement (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
+  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
+  Test / scalacOptions -= "-Wnonunit-statement",
   publishTo := Some(Resolver.evolutionReleases),
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   // set up compiler plugins:
@@ -87,7 +90,7 @@ val alias: Seq[sbt.Def.Setting[?]] =
 
 lazy val root = project
   .in(file("."))
-  .settings(name := "kafka-journal")
+  .settings(name := "kafka-journal-root")
   .settings(commonSettings)
   .settings(publish / skip := true)
   .settings(alias)

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,17 @@ lazy val commonSettings = Seq(
   // -Wnonunit-statement (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
   // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
   Test / scalacOptions -= "-Wnonunit-statement",
+  // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
+  // When a module's instrumented code runs inside another module's forked test JVM (before that
+  // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to
+  // the missing directory. Ensure it always exists after compile whenever coverage is enabled.
+  Compile / compile := Def.uncached {
+    val compiled = (Compile / compile).value
+    if (coverageEnabled.value) {
+      val _ = (crossTarget.value / "scoverage-data").mkdirs()
+    }
+    compiled
+  },
   publishTo := Some(Resolver.evolutionReleases),
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   // set up compiler plugins:

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -33,70 +33,74 @@ object IntegrationSuite {
     }
     def loop(t: Throwable): Boolean =
       indicatesPortInUse(t) ||
-        (t.getCause match {
-          case null => false
-          case cause if cause eq t => false
-          case cause => loop(cause)
+        (Option(t.getCause) match {
+          case Some(cause) if cause ne t => loop(cause)
+          case _ => false
         })
     loop(error)
   }
+
+  private def startContainer[F[_]: Sync, C <: GenericContainer[C]](
+    exposeStaticPort: Int,
+  )(
+    makeContainer: => C,
+  ): F[C] =
+    Sync[F]
+      .blocking {
+        makeContainer.withCreateContainerCmdModifier { cmd =>
+          cmd.withHostConfig(
+            new HostConfig()
+              .withPortBindings(new PortBinding(
+                Ports.Binding.bindPort(exposeStaticPort),
+                new ExposedPort(exposeStaticPort),
+              )),
+          )
+          ()
+        }
+      }
+      .flatMap { container =>
+        Sync[F]
+          .blocking { container.start() }
+          .as(container)
+          // remove the partially-created container so a retry can rebind the port
+          .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+      }
+
+  // The containers bind fixed host ports, so only one test module can use them at a time.
+  // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+  // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+  // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+  // seconds after that JVM exits, so retry startup while the port is still held.
+  private def startContainerWithRetry[F[_]: Async, C <: GenericContainer[C]](
+    log: Log[F],
+    exposeStaticPort: Int,
+    attemptsLeft: Int,
+  )(
+    makeContainer: => C,
+  ): F[C] =
+    startContainer(exposeStaticPort)(makeContainer).handleErrorWith { error =>
+      if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
+      else
+        log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+          Temporal[F].sleep(3.seconds) *>
+          startContainerWithRetry(log, exposeStaticPort, attemptsLeft - 1)(makeContainer)
+    }
 
   private def testContainer[F[_]: Async, C <: GenericContainer[C]](
     log: Log[F],
     exposeStaticPort: Int,
   )(
     makeContainer: => C,
-  ): Resource[F, Unit] = {
-
-    def startContainer: F[C] =
-      Sync[F]
-        .blocking {
-          makeContainer.withCreateContainerCmdModifier { cmd =>
-            cmd.withHostConfig(
-              new HostConfig()
-                .withPortBindings(new PortBinding(
-                  Ports.Binding.bindPort(exposeStaticPort),
-                  new ExposedPort(exposeStaticPort),
-                )),
-            )
-            ()
-          }
-        }
-        .flatMap { container =>
-          Sync[F]
-            .blocking { container.start() }
-            .as(container)
-            // remove the partially-created container so a retry can rebind the port
-            .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-        }
-
-    // The containers bind fixed host ports, so only one test module can use them at a time.
-    // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-    // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-    // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-    // seconds after that JVM exits, so retry startup while the port is still held.
-    def startContainerWithRetry(attemptsLeft: Int): F[C] =
-      startContainer.handleErrorWith { error =>
-        if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-        else
-          log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-            Temporal[F].sleep(3.seconds) *>
-            startContainerWithRetry(attemptsLeft - 1)
-      }
-
+  ): Resource[F, Unit] =
     Resource
       .make {
-        startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+        startContainerWithRetry(log, exposeStaticPort, attemptsLeft = 20)(makeContainer) // ~1 minute total
       } { container =>
         Sync[F]
           .blocking { container.stop() }
-          .onError {
-            case t =>
-              log.error(s"failed to stop $container: ${ t.getMessage }", t)
-          }
+          .onError { case t => log.error(s"failed to stop $container: ${ t.getMessage }", t) }
       }
       .void
-  }
 
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -25,6 +25,79 @@ object IntegrationSuite {
   // Kafka version: 4.0.0 is too new to be the main test version, 3.9.0 container doesn't start
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:3.8.1")
 
+  // Whether the throwable (or any cause in its chain) is a "host port already taken" failure.
+  private def portInUse(error: Throwable): Boolean = {
+    def indicatesPortInUse(t: Throwable): Boolean = {
+      val message = Option(t.getMessage).fold("")(_.toLowerCase)
+      message.contains("already allocated") || message.contains("already in use")
+    }
+    def loop(t: Throwable): Boolean =
+      indicatesPortInUse(t) ||
+        (t.getCause match {
+          case null => false
+          case cause if cause eq t => false
+          case cause => loop(cause)
+        })
+    loop(error)
+  }
+
+  private def testContainer[F[_]: Async, C <: GenericContainer[C]](
+    log: Log[F],
+    exposeStaticPort: Int,
+  )(
+    makeContainer: => C,
+  ): Resource[F, Unit] = {
+
+    def startContainer: F[C] =
+      Sync[F]
+        .blocking {
+          makeContainer.withCreateContainerCmdModifier { cmd =>
+            cmd.withHostConfig(
+              new HostConfig()
+                .withPortBindings(new PortBinding(
+                  Ports.Binding.bindPort(exposeStaticPort),
+                  new ExposedPort(exposeStaticPort),
+                )),
+            )
+            ()
+          }
+        }
+        .flatMap { container =>
+          Sync[F]
+            .blocking { container.start() }
+            .as(container)
+            // remove the partially-created container so a retry can rebind the port
+            .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+        }
+
+    // The containers bind fixed host ports, so only one test module can use them at a time.
+    // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+    // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+    // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+    // seconds after that JVM exits, so retry startup while the port is still held.
+    def startContainerWithRetry(attemptsLeft: Int): F[C] =
+      startContainer.handleErrorWith { error =>
+        if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
+        else
+          log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+            Temporal[F].sleep(3.seconds) *>
+            startContainerWithRetry(attemptsLeft - 1)
+      }
+
+    Resource
+      .make {
+        startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+      } { container =>
+        Sync[F]
+          .blocking { container.stop() }
+          .onError {
+            case t =>
+              log.error(s"failed to stop $container: ${ t.getMessage }", t)
+          }
+      }
+      .void
+  }
+
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
   ): Resource[F, Unit] = {
@@ -34,78 +107,6 @@ object IntegrationSuite {
 
     def kafkaContainer(log: Log[F]): Resource[F, Unit] =
       testContainer(log, exposeStaticPort = 9092)(new KafkaContainer(KafkaDockerImage))
-
-    def testContainer[C <: GenericContainer[C]](
-      log: Log[F],
-      exposeStaticPort: Int,
-    )(
-      makeContainer: => C,
-    ): Resource[F, Unit] = {
-
-      def startContainer: F[C] =
-        Sync[F]
-          .blocking {
-            makeContainer.withCreateContainerCmdModifier { cmd =>
-              cmd.withHostConfig(
-                new HostConfig()
-                  .withPortBindings(new PortBinding(
-                    Ports.Binding.bindPort(exposeStaticPort),
-                    new ExposedPort(exposeStaticPort),
-                  )),
-              )
-              ()
-            }
-          }
-          .flatMap { container =>
-            Sync[F]
-              .blocking { container.start() }
-              .as(container)
-              // remove the partially-created container so a retry can rebind the port
-              .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-          }
-
-      // The containers bind fixed host ports, so only one test module can use them at a time.
-      // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-      // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-      // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-      // seconds after that JVM exits, so retry startup while the port is still held.
-      def portInUse(error: Throwable): Boolean = {
-        @annotation.tailrec
-        def loop(t: Throwable): Boolean = {
-          val message = Option(t.getMessage).fold("")(_.toLowerCase)
-          if (message.contains("already allocated") || message.contains("already in use")) true
-          else
-            t.getCause match {
-              case null => false
-              case cause if cause eq t => false
-              case cause => loop(cause)
-            }
-        }
-        loop(error)
-      }
-
-      def startContainerWithRetry(attemptsLeft: Int): F[C] =
-        startContainer.handleErrorWith { error =>
-          if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-          else
-            log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-              Temporal[F].sleep(3.seconds) *>
-              startContainerWithRetry(attemptsLeft - 1)
-        }
-
-      Resource
-        .make {
-          startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
-        } { container =>
-          Sync[F]
-            .blocking { container.stop() }
-            .onError {
-              case t =>
-                log.error(s"failed to stop $container: ${ t.getMessage }", t)
-            }
-        }
-        .void
-    }
 
     def replicator(log: Log[F]) = {
       implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -17,6 +17,8 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
+import scala.concurrent.duration.*
+
 object IntegrationSuite {
   // Cassandra version: latest 4.x
   private val CassandraDockerImage = DockerImageName.parse("cassandra:4.1.8")
@@ -39,7 +41,8 @@ object IntegrationSuite {
     )(
       makeContainer: => C,
     ): Resource[F, Unit] = {
-      Resource.make {
+
+      def startContainer: F[C] =
         Sync[F].blocking {
           val container = makeContainer
             .withCreateContainerCmdModifier { cmd =>
@@ -55,14 +58,33 @@ object IntegrationSuite {
           container.start()
           container
         }
-      } { container =>
-        Sync[F]
-          .blocking { container.stop() }
-          .onError {
-            case t =>
-              log.error(s"failed to stop $container: ${ t.getMessage }", t)
-          }
-      }.void
+
+      // The containers bind fixed host ports, so only one test module can use them at a time.
+      // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
+      // before shutdown hooks run, so the previous module's cleanup fails to stop its container
+      // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
+      // seconds after that JVM exits, so retry startup for a while to let the port become free.
+      def startContainerWithRetry(attemptsLeft: Int): F[C] =
+        startContainer.handleErrorWith { error =>
+          if (attemptsLeft <= 1) error.raiseError[F, C]
+          else
+            log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
+              Temporal[F].sleep(3.seconds) *>
+              startContainerWithRetry(attemptsLeft - 1)
+        }
+
+      Resource
+        .make {
+          startContainerWithRetry(attemptsLeft = 20) // ~1 minute total
+        } { container =>
+          Sync[F]
+            .blocking { container.stop() }
+            .onError {
+              case t =>
+                log.error(s"failed to stop $container: ${ t.getMessage }", t)
+            }
+        }
+        .void
     }
 
     def replicator(log: Log[F]) = {

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -43,9 +43,9 @@ object IntegrationSuite {
     ): Resource[F, Unit] = {
 
       def startContainer: F[C] =
-        Sync[F].blocking {
-          val container = makeContainer
-            .withCreateContainerCmdModifier { cmd =>
+        Sync[F]
+          .blocking {
+            makeContainer.withCreateContainerCmdModifier { cmd =>
               cmd.withHostConfig(
                 new HostConfig()
                   .withPortBindings(new PortBinding(
@@ -55,18 +55,38 @@ object IntegrationSuite {
               )
               ()
             }
-          container.start()
-          container
-        }
+          }
+          .flatMap { container =>
+            Sync[F]
+              .blocking { container.start() }
+              .as(container)
+              // remove the partially-created container so a retry can rebind the port
+              .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
+          }
 
       // The containers bind fixed host ports, so only one test module can use them at a time.
       // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
       // before shutdown hooks run, so the previous module's cleanup fails to stop its container
       // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-      // seconds after that JVM exits, so retry startup for a while to let the port become free.
+      // seconds after that JVM exits, so retry startup while the port is still held.
+      def portInUse(error: Throwable): Boolean = {
+        @annotation.tailrec
+        def loop(t: Throwable): Boolean = {
+          val message = Option(t.getMessage).fold("")(_.toLowerCase)
+          if (message.contains("already allocated") || message.contains("already in use")) true
+          else
+            t.getCause match {
+              case null => false
+              case cause if cause eq t => false
+              case cause => loop(cause)
+            }
+        }
+        loop(error)
+      }
+
       def startContainerWithRetry(attemptsLeft: Int): F[C] =
         startContainer.handleErrorWith { error =>
-          if (attemptsLeft <= 1) error.raiseError[F, C]
+          if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
           else
             log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
               Temporal[F].sleep(3.seconds) *>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.14
+sbt.version=2.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
-
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
+addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.1.0")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 


### PR DESCRIPTION
Updates sbt to 2.0.2, bumps Evolution plugins, drops sbt-coveralls for coveralls GitHub Action. Replaces #910.