### PR TITLE
Reject per-write serialization failures instead of failing store

### DIFF
--- a/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
+++ b/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
@@ -3,7 +3,7 @@ package com.evolution.kafka.journal.akka.persistence
 import akka.persistence.{AtomicWrite, PersistentRepr}
 import cats.effect.*
 import cats.syntax.all.*
-import cats.{Monad, Parallel, ~>}
+import cats.{Monad, MonadThrow, Parallel, ~>}
 import com.evolution.kafka.journal.*
 import com.evolution.kafka.journal.conversions.{ConversionMetrics, KafkaRead, KafkaWrite}
 import com.evolution.kafka.journal.eventual.cassandra.EventualCassandra
@@ -16,7 +16,7 @@ import com.evolutiongaming.skafka.consumer.ConsumerMetrics
 import com.evolutiongaming.skafka.producer.ProducerMetrics
 import com.evolutiongaming.skafka.{ClientId, CommonConfig}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 trait JournalAdapter[F[_]] {
 
@@ -148,7 +148,7 @@ object JournalAdapter {
     }
   }
 
-  def apply[F[_]: Monad, A](
+  def apply[F[_]: MonadThrow, A](
     journals: Journals[F],
     toKey: ToKey[F],
     serializer: EventSerializer[F, A],
@@ -163,17 +163,35 @@ object JournalAdapter {
     new JournalAdapter[F] {
 
       def write(aws: Seq[AtomicWrite]): F[List[Try[Unit]]] = {
-        val prs = aws.flatMap(_.payload)
-        prs.toList.toNel.foldMapM { prs =>
-          val persistenceId = prs.head.persistenceId
+        aws.flatMap(_.payload).headOption.foldMapM { head =>
+          val persistenceId = head.persistenceId
           for {
             key <- toKey(persistenceId)
-            events <- prs.traverse(serializer.toEvent)
-            metadata <- appendMetadataOf(key, prs, events)
-            journal = journals(key)
-            _ <- journal.append(events, metadata.metadata, metadata.headers)
+            // Serialize each atomic write independently so that a serialization failure is surfaced as a
+            // per-write rejection (`Failure`, routed to `onPersistRejected`) rather than by failing `F` - which
+            // Akka/Pekko treats as a store failure that stops/restarts the persistent actor, taking down the
+            // unrelated valid writes in the same batch.
+            results <- aws.toList.traverse { aw =>
+              aw.payload.toList.toNel.traverse { prs =>
+                prs.traverse(serializer.toEvent).map { events => (prs, events) }
+              }.attempt
+            }
+            accepted = results.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
+            _ <- accepted.toNel.traverse_ { accepted =>
+              val prs = accepted.flatMap { case (prs, _) => prs }
+              val events = accepted.flatMap { case (_, events) => events }
+              for {
+                metadata <- appendMetadataOf(key, prs, events)
+                _ <- journals(key).append(events, metadata.metadata, metadata.headers)
+              } yield {}
+            }
           } yield {
-            List.empty[Try[Unit]]
+            if (results.forall(_.isRight)) List.empty[Try[Unit]]
+            else
+              results.map {
+                case Right(_) => Success(())
+                case Left(error) => Failure(error)
+              }
           }
         }
       }

--- a/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
+++ b/akka/persistence/src/main/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapter.scala
@@ -170,14 +170,16 @@ object JournalAdapter {
             // Serialize each atomic write independently so that a serialization failure is surfaced as a
             // per-write rejection (`Failure`, routed to `onPersistRejected`) rather than by failing `F` - which
             // Akka/Pekko treats as a store failure that stops/restarts the persistent actor, taking down the
-            // unrelated valid writes in the same batch.
+            // unrelated valid writes in the same batch. Writes are accepted only up to the first failure:
+            // rejecting one write while persisting a later one would leave a gap in the sequence numbers.
             results <- aws.toList.traverse { aw =>
               aw.payload.toList.toNel.traverse { prs =>
                 prs.traverse(serializer.toEvent).map { events => (prs, events) }
               }.attempt
             }
-            accepted = results.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
-            _ <- accepted.toNel.traverse_ { accepted =>
+            (accepted, rejected) = results.span(_.isRight)
+            toAppend = accepted.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
+            _ <- toAppend.toNel.traverse_ { accepted =>
               val prs = accepted.flatMap { case (prs, _) => prs }
               val events = accepted.flatMap { case (_, events) => events }
               for {
@@ -186,12 +188,11 @@ object JournalAdapter {
               } yield {}
             }
           } yield {
-            if (results.forall(_.isRight)) List.empty[Try[Unit]]
-            else
-              results.map {
-                case Right(_) => Success(())
-                case Left(error) => Failure(error)
-              }
+            rejected match {
+              case Left(error) :: _ =>
+                accepted.map(_ => Success(())) ::: rejected.map(_ => Failure(error))
+              case _ => List.empty[Try[Unit]]
+            }
           }
         }
       }

--- a/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
+++ b/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
@@ -65,7 +65,13 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
     val awsWithBad = List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)))
     val adapter =
-      JournalAdapter[StateT, Payload](StateT.JournalsStateF, toKey, failingSerializer, journalReadWrite, appendMetadataOf)
+      JournalAdapter[StateT, Payload](
+        StateT.JournalsStateF,
+        toKey,
+        failingSerializer,
+        journalReadWrite,
+        appendMetadataOf,
+      )
     val (data, result) = adapter.write(awsWithBad).run(State.empty).get
     result shouldEqual List(scala.util.Success(()), scala.util.Failure(serializationError))
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))

--- a/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
+++ b/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
@@ -77,6 +77,37 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
   }
 
+  test("write rejects every write following the first serialization failure") {
+    val serializationError = new RuntimeException("serialization failed")
+    val failingSerializer = new EventSerializer[StateT, Payload] {
+      def toEvent(persistentRepr: PersistentRepr): StateT[Event[Payload]] =
+        if (persistentRepr.payload == "bad")
+          cats.data.StateT[Try, State, Event[Payload]] { _ => scala.util.Failure(serializationError) }
+        else event.pure[StateT]
+
+      def toPersistentRepr(persistenceId: PersistenceId, event: Event[Payload]): StateT[PersistentRepr] =
+        persistentRepr.pure[StateT]
+    }
+    val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
+    val awsWithBad =
+      List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)), AtomicWrite(List(persistentRepr)))
+    val adapter =
+      JournalAdapter[StateT, Payload](
+        StateT.JournalsStateF,
+        toKey,
+        failingSerializer,
+        journalReadWrite,
+        appendMetadataOf,
+      )
+    val (data, result) = adapter.write(awsWithBad).run(State.empty).get
+    result shouldEqual List(
+      scala.util.Success(()),
+      scala.util.Failure(serializationError),
+      scala.util.Failure(serializationError),
+    )
+    data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
+  }
+
   test("delete") {
     val (data, _) = journalAdapter.delete(persistenceId, DeleteTo.max).run(State.empty).get
     data shouldEqual State(deletes = List(Delete(key1, DeleteTo.max, timestamp)))

--- a/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
+++ b/akka/persistence/src/test/scala/com/evolution/kafka/journal/akka/persistence/JournalAdapterSpec.scala
@@ -51,6 +51,26 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event, event))))
   }
 
+  test("write rejects the atomic write that fails serialization and keeps the valid ones") {
+    val serializationError = new RuntimeException("serialization failed")
+    val failingSerializer = new EventSerializer[StateT, Payload] {
+      def toEvent(persistentRepr: PersistentRepr): StateT[Event[Payload]] =
+        if (persistentRepr.payload == "bad")
+          cats.data.StateT[Try, State, Event[Payload]] { _ => scala.util.Failure(serializationError) }
+        else event.pure[StateT]
+
+      def toPersistentRepr(persistenceId: PersistenceId, event: Event[Payload]): StateT[PersistentRepr] =
+        persistentRepr.pure[StateT]
+    }
+    val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
+    val awsWithBad = List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)))
+    val adapter =
+      JournalAdapter[StateT, Payload](StateT.JournalsStateF, toKey, failingSerializer, journalReadWrite, appendMetadataOf)
+    val (data, result) = adapter.write(awsWithBad).run(State.empty).get
+    result shouldEqual List(scala.util.Success(()), scala.util.Failure(serializationError))
+    data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
+  }
+
   test("delete") {
     val (data, _) = journalAdapter.delete(persistenceId, DeleteTo.max).run(State.empty).get
     data shouldEqual State(deletes = List(Delete(key1, DeleteTo.max, timestamp)))

--- a/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
+++ b/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
@@ -2,7 +2,7 @@ package com.evolution.kafka.journal.pekko.persistence
 
 import cats.effect.*
 import cats.syntax.all.*
-import cats.{Monad, Parallel, ~>}
+import cats.{Monad, MonadThrow, Parallel, ~>}
 import com.evolution.kafka.journal.*
 import com.evolution.kafka.journal.conversions.{ConversionMetrics, KafkaRead, KafkaWrite}
 import com.evolution.kafka.journal.eventual.cassandra.EventualCassandra
@@ -16,7 +16,7 @@ import com.evolutiongaming.skafka.producer.ProducerMetrics
 import com.evolutiongaming.skafka.{ClientId, CommonConfig}
 import org.apache.pekko.persistence.{AtomicWrite, PersistentRepr}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 trait JournalAdapter[F[_]] {
 
@@ -148,7 +148,7 @@ object JournalAdapter {
     }
   }
 
-  def apply[F[_]: Monad, A](
+  def apply[F[_]: MonadThrow, A](
     journals: Journals[F],
     toKey: ToKey[F],
     serializer: EventSerializer[F, A],
@@ -163,17 +163,35 @@ object JournalAdapter {
     new JournalAdapter[F] {
 
       def write(aws: Seq[AtomicWrite]): F[List[Try[Unit]]] = {
-        val prs = aws.flatMap(_.payload)
-        prs.toList.toNel.foldMapM { prs =>
-          val persistenceId = prs.head.persistenceId
+        aws.flatMap(_.payload).headOption.foldMapM { head =>
+          val persistenceId = head.persistenceId
           for {
             key <- toKey(persistenceId)
-            events <- prs.traverse(serializer.toEvent)
-            metadata <- appendMetadataOf(key, prs, events)
-            journal = journals(key)
-            _ <- journal.append(events, metadata.metadata, metadata.headers)
+            // Serialize each atomic write independently so that a serialization failure is surfaced as a
+            // per-write rejection (`Failure`, routed to `onPersistRejected`) rather than by failing `F` - which
+            // Akka/Pekko treats as a store failure that stops/restarts the persistent actor, taking down the
+            // unrelated valid writes in the same batch.
+            results <- aws.toList.traverse { aw =>
+              aw.payload.toList.toNel.traverse { prs =>
+                prs.traverse(serializer.toEvent).map { events => (prs, events) }
+              }.attempt
+            }
+            accepted = results.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
+            _ <- accepted.toNel.traverse_ { accepted =>
+              val prs = accepted.flatMap { case (prs, _) => prs }
+              val events = accepted.flatMap { case (_, events) => events }
+              for {
+                metadata <- appendMetadataOf(key, prs, events)
+                _ <- journals(key).append(events, metadata.metadata, metadata.headers)
+              } yield {}
+            }
           } yield {
-            List.empty[Try[Unit]]
+            if (results.forall(_.isRight)) List.empty[Try[Unit]]
+            else
+              results.map {
+                case Right(_) => Success(())
+                case Left(error) => Failure(error)
+              }
           }
         }
       }

--- a/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
+++ b/pekko/persistence/src/main/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapter.scala
@@ -170,14 +170,16 @@ object JournalAdapter {
             // Serialize each atomic write independently so that a serialization failure is surfaced as a
             // per-write rejection (`Failure`, routed to `onPersistRejected`) rather than by failing `F` - which
             // Akka/Pekko treats as a store failure that stops/restarts the persistent actor, taking down the
-            // unrelated valid writes in the same batch.
+            // unrelated valid writes in the same batch. Writes are accepted only up to the first failure:
+            // rejecting one write while persisting a later one would leave a gap in the sequence numbers.
             results <- aws.toList.traverse { aw =>
               aw.payload.toList.toNel.traverse { prs =>
                 prs.traverse(serializer.toEvent).map { events => (prs, events) }
               }.attempt
             }
-            accepted = results.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
-            _ <- accepted.toNel.traverse_ { accepted =>
+            (accepted, rejected) = results.span(_.isRight)
+            toAppend = accepted.collect { case Right(Some(prsAndEvents)) => prsAndEvents }
+            _ <- toAppend.toNel.traverse_ { accepted =>
               val prs = accepted.flatMap { case (prs, _) => prs }
               val events = accepted.flatMap { case (_, events) => events }
               for {
@@ -186,12 +188,11 @@ object JournalAdapter {
               } yield {}
             }
           } yield {
-            if (results.forall(_.isRight)) List.empty[Try[Unit]]
-            else
-              results.map {
-                case Right(_) => Success(())
-                case Left(error) => Failure(error)
-              }
+            rejected match {
+              case Left(error) :: _ =>
+                accepted.map(_ => Success(())) ::: rejected.map(_ => Failure(error))
+              case _ => List.empty[Try[Unit]]
+            }
           }
         }
       }

--- a/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
+++ b/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
@@ -65,7 +65,13 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
     val awsWithBad = List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)))
     val adapter =
-      JournalAdapter[StateT, Payload](StateT.JournalsStateF, toKey, failingSerializer, journalReadWrite, appendMetadataOf)
+      JournalAdapter[StateT, Payload](
+        StateT.JournalsStateF,
+        toKey,
+        failingSerializer,
+        journalReadWrite,
+        appendMetadataOf,
+      )
     val (data, result) = adapter.write(awsWithBad).run(State.empty).get
     result shouldEqual List(scala.util.Success(()), scala.util.Failure(serializationError))
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))

--- a/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
+++ b/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
@@ -77,6 +77,37 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
   }
 
+  test("write rejects every write following the first serialization failure") {
+    val serializationError = new RuntimeException("serialization failed")
+    val failingSerializer = new EventSerializer[StateT, Payload] {
+      def toEvent(persistentRepr: PersistentRepr): StateT[Event[Payload]] =
+        if (persistentRepr.payload == "bad")
+          cats.data.StateT[Try, State, Event[Payload]] { _ => scala.util.Failure(serializationError) }
+        else event.pure[StateT]
+
+      def toPersistentRepr(persistenceId: PersistenceId, event: Event[Payload]): StateT[PersistentRepr] =
+        persistentRepr.pure[StateT]
+    }
+    val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
+    val awsWithBad =
+      List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)), AtomicWrite(List(persistentRepr)))
+    val adapter =
+      JournalAdapter[StateT, Payload](
+        StateT.JournalsStateF,
+        toKey,
+        failingSerializer,
+        journalReadWrite,
+        appendMetadataOf,
+      )
+    val (data, result) = adapter.write(awsWithBad).run(State.empty).get
+    result shouldEqual List(
+      scala.util.Success(()),
+      scala.util.Failure(serializationError),
+      scala.util.Failure(serializationError),
+    )
+    data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
+  }
+
   test("delete") {
     val (data, _) = journalAdapter.delete(persistenceId, DeleteTo.max).run(State.empty).get
     data shouldEqual State(deletes = List(Delete(key1, DeleteTo.max, timestamp)))

--- a/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
+++ b/pekko/persistence/src/test/scala/com/evolution/kafka/journal/pekko/persistence/JournalAdapterSpec.scala
@@ -51,6 +51,26 @@ class JournalAdapterSpec extends AnyFunSuite with Matchers {
     data shouldEqual State(appends = List(appendOf(key1, Nel.of(event, event))))
   }
 
+  test("write rejects the atomic write that fails serialization and keeps the valid ones") {
+    val serializationError = new RuntimeException("serialization failed")
+    val failingSerializer = new EventSerializer[StateT, Payload] {
+      def toEvent(persistentRepr: PersistentRepr): StateT[Event[Payload]] =
+        if (persistentRepr.payload == "bad")
+          cats.data.StateT[Try, State, Event[Payload]] { _ => scala.util.Failure(serializationError) }
+        else event.pure[StateT]
+
+      def toPersistentRepr(persistenceId: PersistenceId, event: Event[Payload]): StateT[PersistentRepr] =
+        persistentRepr.pure[StateT]
+    }
+    val badPersistentRepr = PersistentRepr("bad", persistenceId = persistenceId)
+    val awsWithBad = List(AtomicWrite(List(persistentRepr)), AtomicWrite(List(badPersistentRepr)))
+    val adapter =
+      JournalAdapter[StateT, Payload](StateT.JournalsStateF, toKey, failingSerializer, journalReadWrite, appendMetadataOf)
+    val (data, result) = adapter.write(awsWithBad).run(State.empty).get
+    result shouldEqual List(scala.util.Success(()), scala.util.Failure(serializationError))
+    data shouldEqual State(appends = List(appendOf(key1, Nel.of(event))))
+  }
+
   test("delete") {
     val (data, _) = journalAdapter.delete(persistenceId, DeleteTo.max).run(State.empty).get
     data shouldEqual State(deletes = List(Delete(key1, DeleteTo.max, timestamp)))


### PR DESCRIPTION
Per the Akka/Pekko journal contract, a serialization failure for one `AtomicWrite` should surface as a per-write rejection (`Failure` → `onPersistRejected`), not by failing `F`. Failing `F` is treated as a store failure that stops/restarts the persistent actor and drops the other valid writes in the same batch.