### PR TITLE
Bound TopicReplicator key replication concurrency

### DIFF
--- a/replicator/src/main/resources/reference.conf
+++ b/replicator/src/main/resources/reference.conf
@@ -2,7 +2,7 @@ evolutiongaming.kafka-journal.replicator {
 
   # max number of keys replicated concurrently per topic in a single poll;
   # bounds concurrent Cassandra writes, so size it to the Cassandra connection pool
-  replication-parallelism = 100
+  replication-parallelism = 1024
 
   kafka {
     client-id = "replicator"

--- a/replicator/src/main/resources/reference.conf
+++ b/replicator/src/main/resources/reference.conf
@@ -1,5 +1,9 @@
 evolutiongaming.kafka-journal.replicator {
 
+  # max number of keys replicated concurrently per topic in a single poll;
+  # bounds concurrent Cassandra writes, so size it to the Cassandra connection pool
+  replication-parallelism = 100
+
   kafka {
     client-id = "replicator"
     receive-buffer-bytes = 1000000 // 1mb

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/Replicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/Replicator.scala
@@ -83,7 +83,15 @@ object Replicator {
           .fold { TopicReplicatorMetrics.empty[F] } { metrics => metrics(topic) }
 
         val cacheOf = CacheOf[F](config.cacheExpireAfter, metrics.flatMap(_.cache))
-        TopicReplicator.make(topic, journal, consumer, metrics1, cacheOf, replicatedOffsetNotifier)
+        TopicReplicator.make(
+          topic,
+          journal,
+          consumer,
+          metrics1,
+          cacheOf,
+          replicatedOffsetNotifier,
+          config.replicationParallelism,
+        )
       }
 
     val consumer = Consumer.make[F](config.kafka.consumer)

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
@@ -24,7 +24,7 @@ final case class ReplicatorConfig(
     ),
   ),
   pollTimeout: FiniteDuration = 10.millis,
-  replicationParallelism: Int = 1024,
+  replicationParallelism: Long = 1024,
 )
 
 object ReplicatorConfig {
@@ -79,7 +79,7 @@ object ReplicatorConfig {
       kafka = get[KafkaConfig]("kafka") getOrElse default.kafka,
       cassandra = get[EventualCassandraConfig]("cassandra") getOrElse default.cassandra,
       pollTimeout = get[FiniteDuration]("kafka.consumer.poll-timeout") getOrElse default.pollTimeout,
-      replicationParallelism = get[Int]("replication-parallelism") getOrElse default.replicationParallelism,
+      replicationParallelism = 1L.max(get[Long]("replication-parallelism") getOrElse default.replicationParallelism),
     )
   }
 }

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
@@ -24,6 +24,7 @@ final case class ReplicatorConfig(
     ),
   ),
   pollTimeout: FiniteDuration = 10.millis,
+  replicationParallelism: Int = 100,
 )
 
 object ReplicatorConfig {
@@ -78,6 +79,7 @@ object ReplicatorConfig {
       kafka = get[KafkaConfig]("kafka") getOrElse default.kafka,
       cassandra = get[EventualCassandraConfig]("cassandra") getOrElse default.cassandra,
       pollTimeout = get[FiniteDuration]("kafka.consumer.poll-timeout") getOrElse default.pollTimeout,
+      replicationParallelism = get[Int]("replication-parallelism") getOrElse default.replicationParallelism,
     )
   }
 }

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
@@ -24,7 +24,7 @@ final case class ReplicatorConfig(
     ),
   ),
   pollTimeout: FiniteDuration = 10.millis,
-  replicationParallelism: Int = 100,
+  replicationParallelism: Int = 1024,
 )
 
 object ReplicatorConfig {

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.data.{NonEmptyList as Nel, NonEmptyMap as Nem, NonEmptySet as Nes}
 import cats.effect.*
 import cats.effect.implicits.*
+import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import com.evolution.kafka.journal.*
 import com.evolution.kafka.journal.conversions.{ConsRecordToActionRecord, KafkaRead}
@@ -39,6 +40,7 @@ private[journal] object TopicReplicator {
     metrics: TopicReplicatorMetrics[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
+    replicationParallelism: Int,
   ): Resource[F, F[Outcome[F, Throwable, Unit]]] = {
 
     implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
@@ -65,6 +67,7 @@ private[journal] object TopicReplicator {
         log = log,
         cacheOf = cacheOf,
         replicatedOffsetNotifier = replicatedOffsetNotifier,
+        replicationParallelism = replicationParallelism,
       )
     }
 
@@ -89,6 +92,7 @@ private[journal] object TopicReplicator {
     log: Log[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
+    replicationParallelism: Int,
   ): F[Unit] = {
 
     trait PartitionFlow {
@@ -104,6 +108,9 @@ private[journal] object TopicReplicator {
         for {
           journal <- journal.journal(topic)
           cache <- cacheOf[Partition, PartitionFlow](topic)
+          // bounds concurrent per-key replication across all partitions of the topic, so a single
+          // poll spanning many keys cannot exhaust the Cassandra connection pool
+          semaphore <- Semaphore[F](replicationParallelism.max(1).toLong).toResource
         } yield {
 
           def remove(partitions: Nes[Partition]) = {
@@ -149,27 +156,29 @@ private[journal] object TopicReplicator {
                                     .groupBy { _.key.map { _.value } }
                                     .parFoldMap1 {
                                       case (key, records) =>
-                                        key.foldMapM { key =>
-                                          for {
-                                            keyFlow <- cache.getOrUpdate(key) {
-                                              journal
-                                                .journal(key)
-                                                .map { journal =>
-                                                  val replicateRecords = ReplicateRecords(
-                                                    consRecordToActionRecord,
-                                                    journal,
-                                                    metrics,
-                                                    kafkaRead,
-                                                    eventualWrite,
-                                                    log,
-                                                  )
-                                                  (timestamp: Instant, records: Nel[ConsRecord]) => {
-                                                    replicateRecords(records, timestamp)
+                                        semaphore.permit.use { _ =>
+                                          key.foldMapM { key =>
+                                            for {
+                                              keyFlow <- cache.getOrUpdate(key) {
+                                                journal
+                                                  .journal(key)
+                                                  .map { journal =>
+                                                    val replicateRecords = ReplicateRecords(
+                                                      consRecordToActionRecord,
+                                                      journal,
+                                                      metrics,
+                                                      kafkaRead,
+                                                      eventualWrite,
+                                                      log,
+                                                    )
+                                                    (timestamp: Instant, records: Nel[ConsRecord]) => {
+                                                      replicateRecords(records, timestamp)
+                                                    }
                                                   }
-                                                }
-                                            }
-                                            result <- keyFlow(timestamp, records)
-                                          } yield result
+                                              }
+                                              result <- keyFlow(timestamp, records)
+                                            } yield result
+                                          }
                                         }
                                     }
                                 }

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -40,7 +40,7 @@ private[journal] object TopicReplicator {
     metrics: TopicReplicatorMetrics[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
-    replicationParallelism: Int,
+    replicationParallelism: Long,
   ): Resource[F, F[Outcome[F, Throwable, Unit]]] = {
 
     implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
@@ -92,7 +92,7 @@ private[journal] object TopicReplicator {
     log: Log[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
-    replicationParallelism: Int,
+    replicationParallelism: Long,
   ): F[Unit] = {
 
     trait PartitionFlow {
@@ -110,7 +110,7 @@ private[journal] object TopicReplicator {
           cache <- cacheOf[Partition, PartitionFlow](topic)
           // bounds concurrent per-key replication across all partitions of the topic, so a single
           // poll spanning many keys cannot exhaust the Cassandra connection pool
-          semaphore <- Semaphore[F](replicationParallelism.max(1).toLong).toResource
+          semaphore <- Semaphore[F](replicationParallelism).toResource
         } yield {
 
           def remove(partitions: Nes[Partition]) = {

--- a/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorSpec.scala
+++ b/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorSpec.scala
@@ -1090,6 +1090,7 @@ object TopicReplicatorSpec {
       log = Log.empty[StateT],
       cacheOf = CacheOf.empty[StateT],
       replicatedOffsetNotifier = replicatedOffsetNotifier,
+      replicationParallelism = ReplicatorConfig.default.replicationParallelism,
     )
   }
 


### PR DESCRIPTION
The key-level `parFoldMap1` in TopicReplicator started a Cassandra write chain per key with no limit, so a poll spanning thousands of keys could exhaust the connection pool. A per-topic semaphore now bounds concurrent key replication, sized by the new `replication-parallelism` config (default 100).
