### PR TITLE
Package replicator as standalone runnable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ libraryDependencies += "com.evolution" %% "kafka-journal-replicator" % "5.0.0"
 libraryDependencies += "com.evolution" %% "kafka-journal-eventual-cassandra" % "5.0.0"
 ```
 
+## Standalone replicator
+
+The replicator can be built as a self-contained runnable jar:
+
+```sh
+sbt replicatorApp/assembly
+java -Dconfig.file=application.conf -jar replicator-app/target/scala-2.13/kafka-journal-replicator-<version>.jar
+```
+
+Configuration lives under `evolutiongaming.kafka-journal.replicator` (see
+`replicator/src/main/resources/reference.conf`).
+
 ## Migration guide from 4.3.1 to 5.0.0
 
 In `5.0.0` we adapted Evolution's new organization name and changed packages.

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,7 @@ lazy val root = project
     journal,
     snapshot,
     replicator,
+    replicatorApp,
     cassandra,
     eventualCassandra,
     snapshotCassandra,
@@ -278,6 +279,32 @@ lazy val replicator = project
     Logback.Classic % Test,
     ScalaTest % Test,
   ))
+
+lazy val replicatorApp = project
+  .in(file("replicator-app"))
+  .settings(name := "kafka-journal-replicator-app")
+  .settings(commonSettings)
+  .settings(publish / skip := true)
+  .dependsOn(replicator, eventualCassandra)
+  .settings(
+    libraryDependencies ++= Seq(
+      Logback.Core,
+      Logback.Classic,
+    ),
+    Compile / run / fork := true,
+    assembly / mainClass := Some("com.evolution.kafka.journal.replicator.ReplicatorApp"),
+    assembly / assemblyJarName := s"kafka-journal-replicator-${ version.value }.jar",
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+      case PathList("META-INF", xs @ _*) if xs.lastOption.exists(_.endsWith(".SF")) => MergeStrategy.discard
+      case PathList("META-INF", xs @ _*) if xs.lastOption.exists(_.endsWith(".DSA")) => MergeStrategy.discard
+      case PathList("META-INF", xs @ _*) if xs.lastOption.exists(_.endsWith(".RSA")) => MergeStrategy.discard
+      case x if x.endsWith("module-info.class") => MergeStrategy.discard
+      case "reference.conf" => MergeStrategy.concat
+      case "application.conf" => MergeStrategy.concat
+      case _ => MergeStrategy.first
+    },
+  )
 
 lazy val cassandra = project
   .in(file("cassandra"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/replicator-app/src/main/resources/logback.xml
+++ b/replicator-app/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/replicator-app/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorApp.scala
+++ b/replicator-app/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorApp.scala
@@ -1,0 +1,41 @@
+package com.evolution.kafka.journal.replicator
+
+import cats.effect.*
+import cats.effect.unsafe.IORuntime
+import com.evolution.kafka.journal.*
+import com.evolution.kafka.journal.util.Fail
+import com.evolutiongaming.catshelper.*
+import com.evolutiongaming.scassandra.CassandraClusterOf
+import com.evolutiongaming.scassandra.util.FromGFuture
+import com.typesafe.config.ConfigFactory
+
+/**
+ * Standalone entry point running a single [[Replicator]] instance against the Kafka and Cassandra
+ * clusters configured under `evolutiongaming.kafka-journal.replicator` in `application.conf`.
+ */
+object ReplicatorApp extends IOApp {
+
+  override def run(args: List[String]): IO[ExitCode] = {
+
+    implicit val ioRuntime: IORuntime = runtime
+    implicit val fromTry: FromTry[IO] = FromTry.lift[IO]
+    implicit val toTry: ToTry[IO] = ToTry.ioToTry
+    implicit val fail: Fail[IO] = Fail.lift[IO]
+    implicit val fromGFuture: FromGFuture[IO] = FromGFuture.lift1[IO]
+    implicit val measureDuration: MeasureDuration[IO] = MeasureDuration.fromClock(Clock[IO])
+    implicit val jsonCodec: JsonCodec[IO] = JsonCodec.default[IO]
+
+    LogOf.slf4j[IO].flatMap { implicit logOf =>
+      implicit val kafkaConsumerOf: KafkaConsumerOf[IO] = KafkaConsumerOf[IO]()
+      for {
+        log <- logOf(ReplicatorApp.getClass)
+        config <- ReplicatorConfig.fromConfig[IO](ConfigFactory.load())
+        hostName <- HostName.of[IO]()
+        cassandraClusterOf <- CassandraClusterOf.of[IO]
+        _ <- Replicator
+          .make[IO](config, cassandraClusterOf, hostName)
+          .use { done => log.info("replicator started") *> done }
+      } yield ExitCode.Success
+    }
+  }
+}


### PR DESCRIPTION
Closes #15. Adds an `sbt-assembly` fat-jar build for the replicator via a new non-published `replicator-app` module with an `IOApp` entrypoint and logback config. Build: `sbt replicatorApp/assembly`, run: `java -jar <jar>`.