### PR TITLE
Bump sstream 1.2.0, fuse consume loop, add benchmarks

### DIFF
--- a/benchmark/src/test/scala/com/evolution/kafka/journal/ConsumeActionRecordsBenchmark.scala
+++ b/benchmark/src/test/scala/com/evolution/kafka/journal/ConsumeActionRecordsBenchmark.scala
@@ -1,0 +1,80 @@
+package com.evolution.kafka.journal
+
+import cats.data.NonEmptyList as Nel
+import cats.data.NonEmptySet as Nes
+import cats.effect.{Resource, SyncIO}
+import cats.syntax.all.*
+import com.evolution.kafka.journal.conversions.ConsRecordToActionRecord
+import com.evolutiongaming.skafka.consumer.{ConsumerRecord, ConsumerRecords, WithSize}
+import com.evolutiongaming.skafka.{Offset, Partition, TopicPartition}
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Drives the production [[ConsumeActionRecords]] poll loop over a fake [[Journals.Consumer]] that
+ * replays a fixed poll batch, with a stub [[ConsRecordToActionRecord]] so the measured cost is the
+ * per-batch collection plumbing (values/filter/traverseFilter), not payload decoding.
+ *
+ * To run: {{{sbt benchmark/Jmh/run com.evolution.kafka.journal.ConsumeActionRecordsBenchmark}}}
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+class ConsumeActionRecordsBenchmark {
+
+  import ConsumeActionRecordsBenchmark.*
+  import JournalBenchmarkData.key
+
+  // scalastyle:off var.field
+  @Param(Array("1000", "10000"))
+  var size: Int = _
+
+  private val batchSize = 100
+
+  private var consume: ConsumeActionRecords[SyncIO] = _
+  // scalastyle:on var.field
+
+  @Setup
+  def setup(): Unit = {
+    val batch = ConsumerRecords(Map(topicPartition -> Nel.fromListUnsafe(List.fill(batchSize)(consRecord))))
+    val consumer = new Journals.Consumer[SyncIO] {
+      def assign(partitions: Nes[TopicPartition]): SyncIO[Unit] = SyncIO.unit
+      def seek(partition: TopicPartition, offset: Offset): SyncIO[Unit] = SyncIO.unit
+      def poll: SyncIO[ConsRecords] = SyncIO.pure(batch)
+    }
+    consume = ConsumeActionRecords[SyncIO](Resource.pure(consumer))
+  }
+
+  @Benchmark
+  def poll(blackhole: Blackhole): Unit = {
+    val records = consume(key, Partition.min, Offset.min)
+      .take(size.toLong)
+      .toList
+      .unsafeRunSync()
+    blackhole.consume(records)
+  }
+}
+
+object ConsumeActionRecordsBenchmark {
+
+  import JournalBenchmarkData.key
+
+  private val topicPartition = TopicPartition(topic = key.topic, partition = Partition.min)
+
+  private val consRecord: ConsRecord = ConsumerRecord(
+    topicPartition = topicPartition,
+    offset = Offset.min,
+    timestampAndType = none,
+    key = WithSize(key.id).some,
+    value = none,
+    headers = Nil,
+  )
+
+  private val actionRecord: ActionRecord[Action] = JournalBenchmarkData.appendRecord(seqNr = 1L, offset = 0L)
+
+  private implicit val consRecordToActionRecord: ConsRecordToActionRecord[SyncIO] =
+    (_: ConsRecord) => SyncIO.pure(actionRecord.some)
+}

--- a/benchmark/src/test/scala/com/evolution/kafka/journal/JournalBenchmarkData.scala
+++ b/benchmark/src/test/scala/com/evolution/kafka/journal/JournalBenchmarkData.scala
@@ -1,0 +1,26 @@
+package com.evolution.kafka.journal
+
+import cats.syntax.all.*
+import com.evolutiongaming.skafka.Offset
+import scodec.bits.ByteVector
+
+import java.time.Instant
+
+object JournalBenchmarkData {
+
+  val key: Key = Key(topic = "topic", id = "id")
+
+  val timestamp: Instant = Instant.now()
+
+  def appendRecord(seqNr: Long, offset: Long): ActionRecord[Action] = {
+    val header = ActionHeader.Append(
+      range = SeqRange.unsafe(seqNr),
+      origin = none,
+      version = Version.current.some,
+      payloadType = PayloadType.Json,
+      metadata = HeaderMetadata.empty,
+    )
+    val action = Action.Append(key, timestamp, header, ByteVector.empty, Headers.empty)
+    ActionRecord(action, PartitionOffset(offset = Offset.unsafe(offset)))
+  }
+}

--- a/benchmark/src/test/scala/com/evolution/kafka/journal/StreamActionRecordsBenchmark.scala
+++ b/benchmark/src/test/scala/com/evolution/kafka/journal/StreamActionRecordsBenchmark.scala
@@ -1,0 +1,69 @@
+package com.evolution.kafka.journal
+
+import cats.implicits.*
+import com.evolutiongaming.skafka.{Offset, Partition}
+import com.evolutiongaming.sstream.Stream
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Exercises the sstream-based journal read pipeline ([[StreamActionRecords]] over an in-memory
+ * [[ConsumeActionRecords]]) to measure the influence of the sstream dependency.
+ *
+ * To run: {{{sbt benchmark/Jmh/run com.evolution.kafka.journal.StreamActionRecordsBenchmark}}}
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+class StreamActionRecordsBenchmark {
+
+  import JournalBenchmarkData.key
+  import StreamActionRecordsSpec.{State, StateT, bracket}
+
+  // scalastyle:off var.field
+  @Param(Array("1000", "10000"))
+  var size: Int = _
+
+  private var records: List[ActionRecord[Action]] = _
+  private var marker: Marker = _
+  // scalastyle:on var.field
+
+  @Setup
+  def setup(): Unit = {
+    val appends = (1 to size).toList.map { i => JournalBenchmarkData.appendRecord(i.toLong, i.toLong) }
+    val markOffset = Offset.unsafe(size.toLong + 1)
+    val mark = Action.Mark(key, JournalBenchmarkData.timestamp, ActionHeader.Mark("mark", none, Version.current.some))
+    val markRecord = ActionRecord(mark, PartitionOffset(offset = markOffset))
+    marker = Marker(mark.id, PartitionOffset(offset = markOffset))
+    records = appends :+ markRecord
+  }
+
+  @Benchmark
+  def readAll(blackhole: Blackhole): Unit = {
+    blackhole.consume(run(from = SeqNr.min, replicated = None, offset = None))
+  }
+
+  @Benchmark
+  def readTail(blackhole: Blackhole): Unit = {
+    val half = Offset.unsafe(size.toLong / 2)
+    blackhole.consume(run(from = SeqNr.min, replicated = half.some, offset = None))
+  }
+
+  private def run(from: SeqNr, replicated: Option[Offset], offset: Option[Offset]): List[ActionRecord[Action.User]] = {
+    val consume: ConsumeActionRecords[StateT] = { (_: Key, _: Partition, from: Offset) =>
+      val next = StateT { state =>
+        val remaining = state.records.dropWhile { _.offset < from }
+        remaining match {
+          case h :: t => (state.copy(records = t), Stream[StateT].single(h))
+          case Nil => (state, Stream[StateT].empty[ActionRecord[Action]])
+        }
+      }
+      Stream.repeat(next).flatten
+    }
+    val stream = StreamActionRecords[StateT](key, from, marker, replicated, consume)
+    stream(offset).toList.run(State(records)).get._2
+  }
+}

--- a/journal/src/main/scala/com/evolution/kafka/journal/ConsumeActionRecords.scala
+++ b/journal/src/main/scala/com/evolution/kafka/journal/ConsumeActionRecords.scala
@@ -40,15 +40,13 @@ object ConsumeActionRecords {
               actions <- records
                 .values
                 .values
-                .flatMap { records =>
-                  records
-                    .toList
-                    .filter { record =>
-                      record.key.exists { _.value === key.id }
-                    }
-                }
                 .toList
-                .traverseFilter { record => consRecordToActionRecord(record) }
+                .flatTraverse { records =>
+                  records.toList.traverseFilter { record =>
+                    if (record.key.exists { _.value === key.id }) consRecordToActionRecord(record)
+                    else none[ActionRecord[Action]].pure[F]
+                  }
+                }
             } yield actions
           }
           record <- records.toStream1[F]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val CatsHelper = "com.evolutiongaming" %% "cats-helper" % "3.12.2"
   val Random = "com.evolution" %% "random" % "1.0.5"
   val Retry = "com.evolutiongaming" %% "retry" % "3.1.0"
-  val SStream = "com.evolutiongaming" %% "sstream" % "1.1.0"
+  val SStream = "com.evolutiongaming" %% "sstream" % "1.2.0"
   val SKafka = "com.evolutiongaming" %% "skafka" % "21.0.0"
   val AkkaTestActor = "com.evolutiongaming" %% "akka-test-actor" % "0.3.0"
   val PekkoTestActor = "com.evolution" %% "pekko-extension-test-actor" % PekkoExtensionVersion


### PR DESCRIPTION
Bump sstream 1.1.0→1.2.0: source-compatible, all tests green, read path neutral-to-faster. Fuse `ConsumeActionRecords` poll loop into one traverse: ~3.9% allocations/op. Add `StreamActionRecordsBenchmark` and `ConsumeActionRecordsBenchmark` covering the sstream read/consume paths; fix `BatchBenchmark` eta-expansion so the module compiles.