### PR TITLE
Revert "Bound TopicReplicator key replication concurrency" (#936)

### DIFF
--- a/replicator/src/main/resources/reference.conf
+++ b/replicator/src/main/resources/reference.conf
@@ -1,9 +1,5 @@
 evolutiongaming.kafka-journal.replicator {
 
-  # max number of keys replicated concurrently per topic in a single poll;
-  # bounds concurrent Cassandra writes, so size it to the Cassandra connection pool
-  replication-parallelism = 1024
-
   kafka {
     client-id = "replicator"
     receive-buffer-bytes = 1000000 // 1mb

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/Replicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/Replicator.scala
@@ -83,15 +83,7 @@ object Replicator {
           .fold { TopicReplicatorMetrics.empty[F] } { metrics => metrics(topic) }
 
         val cacheOf = CacheOf[F](config.cacheExpireAfter, metrics.flatMap(_.cache))
-        TopicReplicator.make(
-          topic,
-          journal,
-          consumer,
-          metrics1,
-          cacheOf,
-          replicatedOffsetNotifier,
-          config.replicationParallelism,
-        )
+        TopicReplicator.make(topic, journal, consumer, metrics1, cacheOf, replicatedOffsetNotifier)
       }
 
     val consumer = Consumer.make[F](config.kafka.consumer)

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/ReplicatorConfig.scala
@@ -24,7 +24,6 @@ final case class ReplicatorConfig(
     ),
   ),
   pollTimeout: FiniteDuration = 10.millis,
-  replicationParallelism: Long = 1024,
 )
 
 object ReplicatorConfig {
@@ -79,7 +78,6 @@ object ReplicatorConfig {
       kafka = get[KafkaConfig]("kafka") getOrElse default.kafka,
       cassandra = get[EventualCassandraConfig]("cassandra") getOrElse default.cassandra,
       pollTimeout = get[FiniteDuration]("kafka.consumer.poll-timeout") getOrElse default.pollTimeout,
-      replicationParallelism = 1L.max(get[Long]("replication-parallelism") getOrElse default.replicationParallelism),
     )
   }
 }

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -4,7 +4,6 @@ import cats.Monad
 import cats.data.{NonEmptyList as Nel, NonEmptyMap as Nem, NonEmptySet as Nes}
 import cats.effect.*
 import cats.effect.implicits.*
-import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import com.evolution.kafka.journal.*
 import com.evolution.kafka.journal.conversions.{ConsRecordToActionRecord, KafkaRead}
@@ -40,7 +39,6 @@ private[journal] object TopicReplicator {
     metrics: TopicReplicatorMetrics[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
-    replicationParallelism: Long,
   ): Resource[F, F[Outcome[F, Throwable, Unit]]] = {
 
     implicit val fromAttempt: FromAttempt[F] = FromAttempt.lift[F]
@@ -67,7 +65,6 @@ private[journal] object TopicReplicator {
         log = log,
         cacheOf = cacheOf,
         replicatedOffsetNotifier = replicatedOffsetNotifier,
-        replicationParallelism = replicationParallelism,
       )
     }
 
@@ -92,7 +89,6 @@ private[journal] object TopicReplicator {
     log: Log[F],
     cacheOf: CacheOf[F],
     replicatedOffsetNotifier: ReplicatedOffsetNotifier[F],
-    replicationParallelism: Long,
   ): F[Unit] = {
 
     trait PartitionFlow {
@@ -108,9 +104,6 @@ private[journal] object TopicReplicator {
         for {
           journal <- journal.journal(topic)
           cache <- cacheOf[Partition, PartitionFlow](topic)
-          // bounds concurrent per-key replication across all partitions of the topic, so a single
-          // poll spanning many keys cannot exhaust the Cassandra connection pool
-          semaphore <- Semaphore[F](replicationParallelism).toResource
         } yield {
 
           def remove(partitions: Nes[Partition]) = {
@@ -156,29 +149,27 @@ private[journal] object TopicReplicator {
                                     .groupBy { _.key.map { _.value } }
                                     .parFoldMap1 {
                                       case (key, records) =>
-                                        semaphore.permit.use { _ =>
-                                          key.foldMapM { key =>
-                                            for {
-                                              keyFlow <- cache.getOrUpdate(key) {
-                                                journal
-                                                  .journal(key)
-                                                  .map { journal =>
-                                                    val replicateRecords = ReplicateRecords(
-                                                      consRecordToActionRecord,
-                                                      journal,
-                                                      metrics,
-                                                      kafkaRead,
-                                                      eventualWrite,
-                                                      log,
-                                                    )
-                                                    (timestamp: Instant, records: Nel[ConsRecord]) => {
-                                                      replicateRecords(records, timestamp)
-                                                    }
+                                        key.foldMapM { key =>
+                                          for {
+                                            keyFlow <- cache.getOrUpdate(key) {
+                                              journal
+                                                .journal(key)
+                                                .map { journal =>
+                                                  val replicateRecords = ReplicateRecords(
+                                                    consRecordToActionRecord,
+                                                    journal,
+                                                    metrics,
+                                                    kafkaRead,
+                                                    eventualWrite,
+                                                    log,
+                                                  )
+                                                  (timestamp: Instant, records: Nel[ConsRecord]) => {
+                                                    replicateRecords(records, timestamp)
                                                   }
-                                              }
-                                              result <- keyFlow(timestamp, records)
-                                            } yield result
-                                          }
+                                                }
+                                            }
+                                            result <- keyFlow(timestamp, records)
+                                          } yield result
                                         }
                                     }
                                 }

--- a/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorSpec.scala
+++ b/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorSpec.scala
@@ -1090,7 +1090,6 @@ object TopicReplicatorSpec {
       log = Log.empty[StateT],
       cacheOf = CacheOf.empty[StateT],
       replicatedOffsetNotifier = replicatedOffsetNotifier,
-      replicationParallelism = ReplicatorConfig.default.replicationParallelism,
     )
   }
 


### PR DESCRIPTION
The per-topic Semaphore causes a CPU storm: any key replication error cancels all sibling fibers, each running O(n) waiter-queue cleanup in a CAS loop. Reverting as immediate mitigation