### PR TITLE
Do not cancel processing of the whole records batch if one of keys failed

### DIFF
--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -170,8 +170,12 @@ private[journal] object TopicReplicator {
                                             }
                                             result <- keyFlow(timestamp, records)
                                           } yield result
-                                        }.attempt
-                                    }.flatMap { i => Concurrent[F].fromEither(i) }
+                                        }
+                                          // TODO remove `attempt` after CE merges https://github.com/typelevel/cats-effect/pull/4451
+                                          .attempt
+                                    }
+                                    // TODO remove `flatMap` after CE merges https://github.com/typelevel/cats-effect/pull/4451
+                                    .flatMap { Concurrent[F].fromEither }
                                 }
                               result <- {
                                 val offset1 = records.maximumBy { _.offset }.offset

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -170,8 +170,8 @@ private[journal] object TopicReplicator {
                                             }
                                             result <- keyFlow(timestamp, records)
                                           } yield result
-                                        }
-                                    }
+                                        }.attempt
+                                    }.flatMap { i => Concurrent[F].fromEither(i) }
                                 }
                               result <- {
                                 val offset1 = records.maximumBy { _.offset }.offset


### PR DESCRIPTION
Cancelling the whole batch causes a storm of CAS-loop writes on the semaphore.