### PR TITLE
add benchmarks for #957 change (new tests from #960 might need review or adjustments)

### DIFF
--- a/benchmark/src/test/scala/com/evolution/kafka/journal/replicator/ParFoldMap1Benchmark.scala
+++ b/benchmark/src/test/scala/com/evolution/kafka/journal/replicator/ParFoldMap1Benchmark.scala
@@ -1,0 +1,184 @@
+package com.evolution.kafka.journal.replicator
+
+import cats.data.{NonEmptyList, NonEmptyMap}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import com.evolution.kafka.journal.replicator.Poll.{chanceToFailOneIn, error}
+import com.evolutiongaming.catshelper.ParallelHelper.*
+import com.evolutiongaming.skafka.Partition
+import org.openjdk.jmh.annotations.{Benchmark, Fork, Measurement, Scope, State, Warmup}
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.collection.immutable.SortedMap
+import scala.util.Random
+import scala.util.control.NoStackTrace
+
+/**
+ * Benchmarks cancellation effect on hot-path in [[TopicReplicator]] and [[ReplicateRecords]]:
+ *   - `poll` returns `NonEmptyMap[Partition, NonEmptyList[Record[Key, Value]]]`, usually batch
+ *     contains up to 1000 records
+ *   - use `parFoldMap1` to process all partitions in parallel
+ *   - use `parFoldMap1` to process partition's records grouped by key
+ *   - randomly processing of some key may fail, which triggers cancellation of parallel processing
+ *
+ * To run benchmarks:
+ * {{{sbt benchmark/Jmh/run com.evolution.kafka.journal.replicator.ParFoldMap1Benchmark}}}
+ *
+ * Results on Apple M3 Max using Oracle JDK 17
+ * Benchmark                                     Mode  Cnt     Score     Error  Units
+ * ParFoldMap1Benchmark.originalPost11_0_0      thrpt    5  3419.803 ±  43.579  ops/s
+ * ParFoldMap1Benchmark.originalPost11_0_0Plus  thrpt    5  3456.063 ±  42.177  ops/s
+ * ParFoldMap1Benchmark.originalPre11_0_0       thrpt    5  3357.712 ± 155.907  ops/s
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+class ParFoldMap1Benchmark {
+
+  @Benchmark
+  def originalPre11_0_0(blackhole: Blackhole): Unit = {
+    val topicReplicator = TopicReplicatorPre11_0_0(_)
+    run(blackhole, topicReplicator)
+  }
+
+  @Benchmark
+  def originalPost11_0_0(blackhole: Blackhole): Unit = {
+    val topicReplicator = TopicReplicatorPost11_0_0(_)
+    run(blackhole, topicReplicator)
+  }
+
+  @Benchmark
+  def originalPost11_0_0Plus(blackhole: Blackhole): Unit = {
+    val topicReplicator = TopicReplicatorPost11_0_0Plus(_)
+    run(blackhole, topicReplicator)
+  }
+
+  def run(blackhole: Blackhole, topicReplicator: NonEmptyMap[Partition, NonEmptyList[Record]] => IO[Int]): Unit = {
+    blackhole.consume(
+      IO(Poll.generate)
+        .flatMap {
+          topicReplicator(_)
+            .handleError { _ => 0 }
+        }
+        .unsafeRunSync(),
+    )
+  }
+}
+
+//object Test extends IOApp {
+//
+//  override def run(args: List[String]): IO[ExitCode] = {
+//    val result = {
+//      IO(Poll.generate).flatMap {
+//        TopicReplicatorPost11_0_0(_)
+//          .handleError { e => println(s"got error: $e"); 0 }
+//          .map { total => println(s"processed: $total"); total }
+//      }
+//    }
+//    result.replicateA(10).map(_.sum).map(sum => println(s"sum: $sum")).as(ExitCode.Success)
+//  }
+//
+//}
+
+case class Record(key: String, value: Int)
+
+object Poll {
+
+  val chanceToFailOneIn = 1_00
+  val error: Throwable = new RuntimeException("ba-bam!") with NoStackTrace
+
+  def generate: NonEmptyMap[Partition, NonEmptyList[Record]] = {
+    val numberOfKeys = Random.nextInt(250) + 1
+    val numberOfRecords = Random.nextInt(1000) + 1
+    val numberOfPartitions = Random.nextInt(16) + 1
+
+    val keys = (0 until numberOfKeys).map(i => s"key: $i")
+    val records = (0 until numberOfRecords).map(Record(keys(Random.nextInt(numberOfKeys)), _))
+
+    NonEmptyMap.fromMapUnsafe {
+      SortedMap.from {
+        records.groupBy(_.value % numberOfPartitions).map { case (p, r) =>
+          Partition.unsafe(p) -> NonEmptyList.fromListUnsafe(r.toList)
+        }
+      }
+    }
+  }
+}
+
+object ReplicateRecords {
+  def process(record: Record): IO[NonEmptyList[Int]] =
+    if (Random.nextInt(chanceToFailOneIn) == 0) IO.raiseError(error)
+    else IO(NonEmptyList.one(1))
+}
+
+// Pre11_0_0 - "clean" version
+object TopicReplicatorPre11_0_0 {
+  def apply(records: NonEmptyMap[Partition, NonEmptyList[Record]]): IO[Int] = {
+    for {
+      result <- records.parFoldMap1 {
+        case (partition, records) =>
+          records
+            .groupBy { _.key }
+            .parFoldMap1 {
+              case (key, records) =>
+                for {
+                  result <- records.flatTraverse(ReplicateRecords.process)
+                  size <- result.size.pure[IO]
+                } yield size
+            }
+      }
+    } yield result
+  }
+}
+
+// Post11_0_0 - each processing returns `Either` and we `.flatMap { Concurrent[F].fromEither }`
+object TopicReplicatorPost11_0_0 {
+
+  def apply(records: NonEmptyMap[Partition, NonEmptyList[Record]]): IO[Int] = {
+    for {
+      result <- records.parFoldMap1 {
+        case (partition, records) =>
+          records
+            .groupBy { _.key }
+            .parFoldMap1 {
+              case (key, records) =>
+                val result = for {
+                  result <- records.flatTraverse(ReplicateRecords.process)
+                  size <- result.size.pure[IO]
+                } yield size
+                result.attempt
+            }
+            .flatMap { IO.fromEither }
+      }
+    } yield result
+  }
+}
+
+// Post11_0_0Plus - each processing returns `Either` and we `.flatMap { Concurrent[F].fromEither }`
+object TopicReplicatorPost11_0_0Plus {
+
+  def apply(records: NonEmptyMap[Partition, NonEmptyList[Record]]): IO[Int] = {
+    for {
+      result <- records.parFoldMap1 {
+        case (partition, records) =>
+          val result = records
+            .groupBy { _.key }
+            .parFoldMap1 {
+              case (key, records) =>
+                val result = for {
+                  result <- records.flatTraverse(ReplicateRecords.process)
+                  size <- result.size.pure[IO]
+                } yield size
+                result.attempt
+            }
+            .flatMap { IO.fromEither }
+
+          result.attempt
+      }
+        .flatMap { IO.fromEither }
+    } yield result
+  }
+}

--- a/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
+++ b/replicator/src/main/scala/com/evolution/kafka/journal/replicator/TopicReplicator.scala
@@ -122,7 +122,7 @@ private[journal] object TopicReplicator {
                 timestamp <- Clock[F].instant
                 _ <- records.parFoldMap1 {
                   case (partition, records) =>
-                    for {
+                    val replicatePartition = for {
                       partitionFlow <- cache.getOrUpdate(partition) {
                         for {
                           journal <- journal(partition)
@@ -205,7 +205,11 @@ private[journal] object TopicReplicator {
                       }
                       result <- partitionFlow(timestamp, records)
                     } yield result
+                    // TODO remove `attempt` after CE merges https://github.com/typelevel/cats-effect/pull/4451
+                    replicatePartition.attempt
                 }
+                  // TODO remove `flatMap` after CE merges https://github.com/typelevel/cats-effect/pull/4451
+                  .flatMap { Concurrent[F].fromEither }
                 duration <- duration
                 _ <- metrics.round(duration, records.foldLeft(0) { _ + _.size })
               } yield {

--- a/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorCancellationTest.scala
+++ b/replicator/src/test/scala/com/evolution/kafka/journal/replicator/TopicReplicatorCancellationTest.scala
@@ -11,6 +11,7 @@ import com.evolutiongaming.catshelper.{Log, MeasureDuration}
 import com.evolutiongaming.skafka.*
 import com.evolutiongaming.skafka.consumer.{ConsumerRecord, RebalanceListener1, WithSize}
 import com.evolutiongaming.sstream.Stream
+import org.scalatest.Assertion
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
@@ -24,23 +25,33 @@ class TopicReplicatorCancellationTest extends AsyncFunSuite with Matchers {
 
   import TopicReplicatorCancellationTest.*
 
-  test("key failure does not cancel other keys of the same partition") {
-    replicateOkAndBad { Map((Partition.min, Nel.of(record("ok", 0, 0), record("bad", 0, 1)))) }
+  test("key failure does not cancel other keys on the same partition") {
+    val partition = Partition.unsafe(0)
+    replicateOkAndBad {
+      Map(
+        partition ->
+          Nel.of(
+            record(key = "ok", partition = partition.value, offset = 0),
+            record(key = "bad", partition = partition.value, offset = 1),
+          ),
+      )
+    }
       .unsafeToFuture()
   }
 
-  test("key failure does not cancel keys of other partitions") {
-    val records = Map(
-      (Partition.unsafe(0), Nel.of(record("bad", 0, 0))),
-      (Partition.unsafe(1), Nel.of(record("ok", 1, 0))),
-    )
-    pendingUntilFixed {
-      replicateOkAndBad(records).unsafeRunSync()
-      ()
+  test("key failure does not cancel keys on other partitions") {
+    val partition0 = Partition.unsafe(0)
+    val partition1 = Partition.unsafe(1)
+    replicateOkAndBad {
+      Map(
+        partition0 -> Nel.of(record(key = "bad", partition = partition0.value, offset = 0)),
+        partition1 -> Nel.of(record(key = "ok", partition = partition1.value, offset = 0)),
+      )
     }
+      .unsafeToFuture()
   }
 
-  private def replicateOkAndBad(records: Map[Partition, Nel[ConsRecord]]) = {
+  private def replicateOkAndBad(records: Map[Partition, Nel[ConsRecord]]): IO[Assertion] = {
     for {
       started <- Deferred[IO, Unit]
       finished <- Deferred[IO, Unit]
@@ -73,19 +84,17 @@ object TopicReplicatorCancellationTest {
   implicit val measureDuration: MeasureDuration[IO] = MeasureDuration.fromClock(Clock[IO])
 
   val consRecordToActionRecord: ConsRecordToActionRecord[IO] = { (record: ConsRecord) =>
-    {
-      record
-        .key
-        .traverse { key =>
-          val action = Action.delete(
-            key = Key(id = key.value, topic = record.topic),
-            timestamp = Instant.EPOCH,
-            header = ActionHeader.Delete(SeqNr.min.toDeleteTo, none, none),
-          )
-          val partitionOffset = PartitionOffset(record.topicPartition.partition, record.offset)
-          ActionRecord(action, partitionOffset).pure[IO]
-        }
-    }
+    record
+      .key
+      .traverse { key =>
+        val action = Action.delete(
+          key = Key(id = key.value, topic = record.topic),
+          timestamp = Instant.EPOCH,
+          header = ActionHeader.Delete(SeqNr.min.toDeleteTo, none, none),
+        )
+        val partitionOffset = PartitionOffset(record.topicPartition.partition, record.offset)
+        ActionRecord(action, partitionOffset).pure[IO]
+      }
   }
 
   val kafkaRead: KafkaRead[IO, Unit] = { (_: PayloadAndType) =>


### PR DESCRIPTION
Related to #957 and #960.

Assuming that benchmark is valid, there is no improvement in cancellation handling.

```
Results on Apple M3 Max using Oracle JDK 17
Benchmark                                     Mode  Cnt     Score     Error  Units
ParFoldMap1Benchmark.originalPost11_0_0      thrpt    5  3419.803 ±  43.579  ops/s
ParFoldMap1Benchmark.originalPost11_0_0Plus  thrpt    5  3456.063 ±  42.177  ops/s
ParFoldMap1Benchmark.originalPre11_0_0       thrpt    5  3357.712 ± 155.907  ops/s
```