### PR TITLE
Revert migration to sbt 2

### DIFF
--- a/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/akka/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -17,88 +17,9 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
-import scala.concurrent.duration.*
-
 object IntegrationSuite {
   private val CassandraDockerImage = DockerImageName.parse("cassandra:5.0.8")
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:4.3.1")
-
-  // Whether the throwable (or any cause in its chain) is a "host port already taken" failure.
-  private def portInUse(error: Throwable): Boolean = {
-    def indicatesPortInUse(t: Throwable): Boolean = {
-      val message = Option(t.getMessage).fold("")(_.toLowerCase)
-      message.contains("already allocated") || message.contains("already in use")
-    }
-    def loop(t: Throwable): Boolean =
-      indicatesPortInUse(t) ||
-        (Option(t.getCause) match {
-          case Some(cause) if cause ne t => loop(cause)
-          case _ => false
-        })
-    loop(error)
-  }
-
-  private def startContainer[F[_]: Sync, C <: GenericContainer[C]](
-    exposeStaticPort: Int,
-  )(
-    makeContainer: => C,
-  ): F[C] =
-    Sync[F]
-      .blocking {
-        makeContainer.withCreateContainerCmdModifier { cmd =>
-          cmd.withHostConfig(
-            new HostConfig()
-              .withPortBindings(new PortBinding(
-                Ports.Binding.bindPort(exposeStaticPort),
-                new ExposedPort(exposeStaticPort),
-              )),
-          )
-          ()
-        }
-      }
-      .flatMap { container =>
-        Sync[F]
-          .blocking { container.start() }
-          .as(container)
-          // remove the partially-created container so a retry can rebind the port
-          .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-      }
-
-  // The containers bind fixed host ports, so only one test module can use them at a time.
-  // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-  // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-  // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-  // seconds after that JVM exits, so retry startup while the port is still held.
-  private def startContainerWithRetry[F[_]: Async, C <: GenericContainer[C]](
-    log: Log[F],
-    exposeStaticPort: Int,
-    attemptsLeft: Int,
-  )(
-    makeContainer: => C,
-  ): F[C] =
-    startContainer(exposeStaticPort)(makeContainer).handleErrorWith { error =>
-      if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-      else
-        log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-          Temporal[F].sleep(3.seconds) *>
-          startContainerWithRetry(log, exposeStaticPort, attemptsLeft - 1)(makeContainer)
-    }
-
-  private def testContainer[F[_]: Async, C <: GenericContainer[C]](
-    log: Log[F],
-    exposeStaticPort: Int,
-  )(
-    makeContainer: => C,
-  ): Resource[F, Unit] =
-    Resource
-      .make {
-        startContainerWithRetry(log, exposeStaticPort, attemptsLeft = 20)(makeContainer) // ~1 minute total
-      } { container =>
-        Sync[F]
-          .blocking { container.stop() }
-          .onError { case t => log.error(s"failed to stop $container: ${ t.getMessage }", t) }
-      }
-      .void
 
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
@@ -109,6 +30,38 @@ object IntegrationSuite {
 
     def kafkaContainer(log: Log[F]): Resource[F, Unit] =
       testContainer(log, exposeStaticPort = 9092)(new KafkaContainer(KafkaDockerImage))
+
+    def testContainer[C <: GenericContainer[C]](
+      log: Log[F],
+      exposeStaticPort: Int,
+    )(
+      makeContainer: => C,
+    ): Resource[F, Unit] = {
+      Resource.make {
+        Sync[F].blocking {
+          val container = makeContainer
+            .withCreateContainerCmdModifier { cmd =>
+              cmd.withHostConfig(
+                new HostConfig()
+                  .withPortBindings(new PortBinding(
+                    Ports.Binding.bindPort(exposeStaticPort),
+                    new ExposedPort(exposeStaticPort),
+                  )),
+              )
+              ()
+            }
+          container.start()
+          container
+        }
+      } { container =>
+        Sync[F]
+          .blocking { container.stop() }
+          .onError {
+            case t =>
+              log.error(s"failed to stop $container: ${ t.getMessage }", t)
+          }
+      }.void
+    }
 
     def replicator(log: Log[F]) = {
       implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import sbt.Package.ManifestAttributes
 lazy val commonSettings = Seq(
   organization := "com.evolution",
   organizationName := "Evolution",
-  organizationHomepage := Some(uri("https://evolution.com")),
-  homepage := Some(uri("https://github.com/evolution-gaming/kafka-journal")),
+  organizationHomepage := Some(url("https://evolution.com")),
+  homepage := Some(url("https://github.com/evolution-gaming/kafka-journal")),
   startYear := Some(2018),
   crossScalaVersions := Seq("2.13.18", "3.3.8"),
   scalaVersion := crossScalaVersions.value.head,
@@ -37,19 +37,8 @@ lazy val commonSettings = Seq(
   ),
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
-  // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
-  // When a module's instrumented code runs inside another module's forked test JVM (before that
-  // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to
-  // the missing directory. Ensure it always exists after compile whenever coverage is enabled.
-  Compile / compile := Def.uncached {
-    val compiled = (Compile / compile).value
-    if (coverageEnabled.value) {
-      val _ = (crossTarget.value / "scoverage-data").mkdirs()
-    }
-    compiled
-  },
   publishTo := Some(Resolver.evolutionReleases),
-  licenses := Seq(("MIT", uri("https://opensource.org/licenses/MIT"))),
+  licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   // set up compiler plugins:
   libraryDependencies ++= crossSettings(
     scalaVersion = scalaVersion.value,
@@ -94,12 +83,11 @@ val alias: Seq[sbt.Def.Setting[?]] =
       "check", // check is called with + from the release action
       "all versionPolicyCheck Compile/doc scalafmtCheckRepo",
     ) ++
-    addCommandAlias("build", "all compile testFull")
+    addCommandAlias("build", "+all compile test")
 
 lazy val root = project
   .in(file("."))
   .settings(name := "kafka-journal")
-  .settings(normalizedName := "root")
   .settings(commonSettings)
   .settings(publish / skip := true)
   .settings(alias)

--- a/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
+++ b/pekko/tests/src/test/scala/com/evolution/kafka/journal/IntegrationSuite.scala
@@ -17,88 +17,9 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
-import scala.concurrent.duration.*
-
 object IntegrationSuite {
   private val CassandraDockerImage = DockerImageName.parse("cassandra:5.0.8")
   private val KafkaDockerImage = DockerImageName.parse("apache/kafka-native:4.3.1")
-
-  // Whether the throwable (or any cause in its chain) is a "host port already taken" failure.
-  private def portInUse(error: Throwable): Boolean = {
-    def indicatesPortInUse(t: Throwable): Boolean = {
-      val message = Option(t.getMessage).fold("")(_.toLowerCase)
-      message.contains("already allocated") || message.contains("already in use")
-    }
-    def loop(t: Throwable): Boolean =
-      indicatesPortInUse(t) ||
-        (Option(t.getCause) match {
-          case Some(cause) if cause ne t => loop(cause)
-          case _ => false
-        })
-    loop(error)
-  }
-
-  private def startContainer[F[_]: Sync, C <: GenericContainer[C]](
-    exposeStaticPort: Int,
-  )(
-    makeContainer: => C,
-  ): F[C] =
-    Sync[F]
-      .blocking {
-        makeContainer.withCreateContainerCmdModifier { cmd =>
-          cmd.withHostConfig(
-            new HostConfig()
-              .withPortBindings(new PortBinding(
-                Ports.Binding.bindPort(exposeStaticPort),
-                new ExposedPort(exposeStaticPort),
-              )),
-          )
-          ()
-        }
-      }
-      .flatMap { container =>
-        Sync[F]
-          .blocking { container.start() }
-          .as(container)
-          // remove the partially-created container so a retry can rebind the port
-          .onError { case _ => Sync[F].blocking { container.stop() }.handleError(_ => ()) }
-      }
-
-  // The containers bind fixed host ports, so only one test module can use them at a time.
-  // Under sbt 2 the forked-test JVM closes its classloader (and the cats-effect runtime)
-  // before shutdown hooks run, so the previous module's cleanup fails to stop its container
-  // and it leaks the port. The out-of-process testcontainers Ryuk reaper frees it a few
-  // seconds after that JVM exits, so retry startup while the port is still held.
-  private def startContainerWithRetry[F[_]: Async, C <: GenericContainer[C]](
-    log: Log[F],
-    exposeStaticPort: Int,
-    attemptsLeft: Int,
-  )(
-    makeContainer: => C,
-  ): F[C] =
-    startContainer(exposeStaticPort)(makeContainer).handleErrorWith { error =>
-      if (attemptsLeft <= 1 || !portInUse(error)) error.raiseError[F, C]
-      else
-        log.warn(s"failed to start container on port $exposeStaticPort, retrying: ${ error.getMessage }") *>
-          Temporal[F].sleep(3.seconds) *>
-          startContainerWithRetry(log, exposeStaticPort, attemptsLeft - 1)(makeContainer)
-    }
-
-  private def testContainer[F[_]: Async, C <: GenericContainer[C]](
-    log: Log[F],
-    exposeStaticPort: Int,
-  )(
-    makeContainer: => C,
-  ): Resource[F, Unit] =
-    Resource
-      .make {
-        startContainerWithRetry(log, exposeStaticPort, attemptsLeft = 20)(makeContainer) // ~1 minute total
-      } { container =>
-        Sync[F]
-          .blocking { container.stop() }
-          .onError { case t => log.error(s"failed to stop $container: ${ t.getMessage }", t) }
-      }
-      .void
 
   def startF[F[_]: Async: LogOf: MeasureDuration: FromTry: ToTry: Fail](
     cassandraClusterOf: CassandraClusterOf[F],
@@ -109,6 +30,38 @@ object IntegrationSuite {
 
     def kafkaContainer(log: Log[F]): Resource[F, Unit] =
       testContainer(log, exposeStaticPort = 9092)(new KafkaContainer(KafkaDockerImage))
+
+    def testContainer[C <: GenericContainer[C]](
+      log: Log[F],
+      exposeStaticPort: Int,
+    )(
+      makeContainer: => C,
+    ): Resource[F, Unit] = {
+      Resource.make {
+        Sync[F].blocking {
+          val container = makeContainer
+            .withCreateContainerCmdModifier { cmd =>
+              cmd.withHostConfig(
+                new HostConfig()
+                  .withPortBindings(new PortBinding(
+                    Ports.Binding.bindPort(exposeStaticPort),
+                    new ExposedPort(exposeStaticPort),
+                  )),
+              )
+              ()
+            }
+          container.start()
+          container
+        }
+      } { container =>
+        Sync[F]
+          .blocking { container.stop() }
+          .onError {
+            case t =>
+              log.error(s"failed to stop $container: ${ t.getMessage }", t)
+          }
+      }.void
+    }
 
     def replicator(log: Log[F]) = {
       implicit val kafkaConsumerOf: KafkaConsumerOf[F] = KafkaConsumerOf[F]()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 2.0.6
+sbt.version = 1.12.15


### PR DESCRIPTION
Temporary fix for this issue:
https://github.com/evolution-gaming/kafka-journal/issues/961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Maintenance**
  * Updated the project’s build tooling and metadata.
  * Improved cross-version build and test execution.
  * Simplified compilation and coverage-related build behavior.

* **Test Infrastructure**
  * Simplified integration-test container startup and shutdown handling.
  * Removed retry-based startup behavior and port-conflict detection.
  * Preserved error logging during container cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->