### PR TITLE
Set up single status check for all CI action sub-jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,16 @@ permissions:
 jobs:
   test:
     uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1
+
+  # to have one CI job status check for branch protection rules
+  # see: https://github.com/re-actors/alls-green
+  all-green:
+    if: always()
+    needs:
+      - test
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     runs-on: Ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # v1.3.0
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This is needed for master branch protection rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an aggregate continuous integration status check.
  * Branch protection can now rely on a single status that reflects the overall test result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->